### PR TITLE
[feat] Validate exoneration date

### DIFF
--- a/cr_electronic_invoice/models/account_invoice.py
+++ b/cr_electronic_invoice/models/account_invoice.py
@@ -1331,6 +1331,9 @@ class AccountInvoiceElectronic(models.Model):
                 super(AccountInvoiceElectronic, inv).action_invoice_open()
                 inv.tipo_documento = None
                 continue
+            
+            if inv.partner_id.has_exoneration and inv.partner_id.date_expiration and (inv.partner_id.date_expiration < datetime.date.today()):
+                raise UserError('La exoneración de este cliente se encuentra vencida')
 
             currency = inv.currency_id
             sequence = False

--- a/cr_electronic_invoice/views/product_views.xml
+++ b/cr_electronic_invoice/views/product_views.xml
@@ -28,7 +28,7 @@
                     <field name="economic_activity_id" 
                         domain="[('active', '=', True)]" 
                         options='{"no_open": True, "no_create": True}'/>
-                        <field name="cabys_code" />
+                    <field name="cabys_code" />
                 </field>
             </field>
         </record>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Validates if client exoneration is not expired

Current behavior before PR:
There is no validation. The user realized that when Hacienda rejects the invoice

Desired behavior after PR is merged:
Message alert when the invoice is created and validated.