### PR TITLE
Optional phone number for XML provider

### DIFF
--- a/cr_electronic_invoice/models/api_facturae.py
+++ b/cr_electronic_invoice/models/api_facturae.py
@@ -992,7 +992,12 @@ def load_xml_data(invoice, load_lines, account_id, product_id=False, analytic_ac
     tipo_emisor = invoice_xml.xpath("inv:Emisor/inv:Identificacion/inv:Tipo", namespaces=namespaces)[0].text
     nombre_emisor = invoice_xml.xpath("inv:Emisor/inv:Nombre", namespaces=namespaces)[0].text
     pais_emisor = invoice.env['res.country'].search([('name', '=', 'Costa Rica')], limit=1).id
-    telefono_emisor = invoice_xml.xpath("inv:Emisor/inv:Telefono/inv:NumTelefono", namespaces=namespaces)[0].text
+
+    telefono_emisor_node = invoice_xml.xpath("inv:Emisor/inv:Telefono/inv:NumTelefono", namespaces=namespaces)
+    telefono_emisor = False
+    if telefono_emisor_node:
+        telefono_emisor = invoice_xml.xpath("inv:Emisor/inv:Telefono/inv:NumTelefono", namespaces=namespaces)[0].text
+
     otrassenas_emisor = invoice_xml.xpath("inv:Emisor/inv:Ubicacion/inv:OtrasSenas", namespaces=namespaces)[0].text
     correo_emisor = invoice_xml.xpath("inv:Emisor/inv:CorreoElectronico", namespaces=namespaces)[0].text
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When the provider sends the XML file of an invoice, Odoo is requesting the phone number as required, but for "Hacienda" it is optional.

Current behavior before PR:
Phone number is required for any XML invoice.

Desired behavior after PR is merged:
Phone number is optional for any XML invoice.