### PR TITLE
[hotfix] partner's exoneration date validation

### DIFF
--- a/cr_electronic_invoice/models/account_move.py
+++ b/cr_electronic_invoice/models/account_move.py
@@ -1406,8 +1406,8 @@ class AccountInvoiceElectronic(models.Model):
                 inv.tipo_documento = 'disabled'
                 continue
 
-            if inv.partner_id.has_exoneration:
-                if inv.partner_id.date_expiration and (inv.partner_id.date_expiration > datetime.date.today()):
+            if inv.partner_id.has_exoneration and inv.partner_id.date_expiration and \
+                (inv.partner_id.date_expiration < datetime.date.today()):
                     raise UserError(_('The exoneration of this client has expired'))
 
             currency = inv.currency_id


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The issue is that it does not allow to confirm the invoices of the clients that have exoneration, because it says that the client's exoneration date is expired but when the client's exoneration date is checked, the date was not expired yet.

Current behavior before PR:
When an invoice of a client that has an exoneration is confirmed, it does not allow confirmation because it says that the exoneration date is expired but it is not true, the exoneration date is still valid.

Desired behavior after PR is merged:
That the validation is done correctly and that it allows the invoice to be confirmed if the client's exoneration date is greater than the current date.