### PR TITLE
[fix] Don't duplicate economic activity provider

### DIFF
--- a/cr_electronic_invoice/views/res_partner_views.xml
+++ b/cr_electronic_invoice/views/res_partner_views.xml
@@ -23,7 +23,7 @@
                     <separator colspan="7"/>
                     <field name="activity_id" domain="[('id', 'in', economic_activities_ids)]" options="{&quot;no_create&quot;: True, &quot;active_test&quot;: False}" colspan="5" />
                     <button name="action_get_economic_activities" type="object" string="Consultar Actividad Economica en Hacienda" colspan="2" />
-                    <field name="economic_activities_ids" readonly="0" widget="section_and_note_one2many" mode="tree" context="{'partner_id': id}" colspan="7">
+                    <field name="economic_activities_ids" readonly="0" widget="many2many" mode="tree" context="{'partner_id': id}" colspan="7">
                         <tree editable="bottom">
                             <field name="code" />
                             <field name="name"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When add a economic activity for a provider, a new electronic activity is created instead of shows all the activities registered in the system

Current behavior before PR:
The economic activity field create a new economic activity.

Desired behavior after PR is merged:
The economic activity field now shows all the activities registered in the system.