### PR TITLE
Fix/fee receptor

### DIFF
--- a/cr_electronic_invoice/models/api_facturae.py
+++ b/cr_electronic_invoice/models/api_facturae.py
@@ -444,7 +444,7 @@ def gen_xml_v4_4(inv, sale_conditions, total_servicio_gravado,
         else:
             id_code = receiver_company.identification_id.code
 
-        if receiver_company.name:
+        if receiver_company.name and inv.tipo_documento != 'FEE':
             sb.append('<Receptor>')
             sb.append('<Nombre>' + escape(str(receiver_company.name[:99])) + '</Nombre>')
 

--- a/cr_electronic_invoice/models/api_facturae.py
+++ b/cr_electronic_invoice/models/api_facturae.py
@@ -14,7 +14,7 @@ import random
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 
-from odoo import _
+from odoo import _, tools
 from odoo.exceptions import UserError
 from xml.sax.saxutils import escape
 from ..xades.context2 import XAdESContext2, PolicyId2, create_xades_epes_signature
@@ -695,7 +695,7 @@ def gen_xml_v4_4(inv, sale_conditions, total_servicio_gravado,
         sb.append('</InformacionReferencia>')
     if invoice_comments:
         sb.append('<Otros>')
-        sb.append('<OtroTexto>' + str(invoice_comments) + '</OtroTexto>')
+        sb.append('<OtroTexto>' + tools.html2plaintext(str(invoice_comments))[0:500] + '</OtroTexto>')
         sb.append('</Otros>')
 
     sb.append('</' + fe_enums.tagName[inv.tipo_documento] + '>')

--- a/cr_electronic_invoice/models/api_facturae.py
+++ b/cr_electronic_invoice/models/api_facturae.py
@@ -695,7 +695,7 @@ def gen_xml_v4_4(inv, sale_conditions, total_servicio_gravado,
         sb.append('</InformacionReferencia>')
     if invoice_comments:
         sb.append('<Otros>')
-        sb.append('<OtroTexto>' + str(invoice_comments)[0:500] + '</OtroTexto>')
+        sb.append('<OtroTexto>' + str(invoice_comments) + '</OtroTexto>')
         sb.append('</Otros>')
 
     sb.append('</' + fe_enums.tagName[inv.tipo_documento] + '>')

--- a/cr_electronic_invoice/models/api_facturae.py
+++ b/cr_electronic_invoice/models/api_facturae.py
@@ -444,15 +444,13 @@ def gen_xml_v4_4(inv, sale_conditions, total_servicio_gravado,
         else:
             id_code = receiver_company.identification_id.code
 
-        if receiver_company.name and inv.tipo_documento != 'FEE':
+        if receiver_company.name:
             sb.append('<Receptor>')
             sb.append('<Nombre>' + escape(str(receiver_company.name[:99])) + '</Nombre>')
-
-            if not (inv.tipo_documento == 'FEE' or id_code == '05'):
-                sb.append('<Identificacion>')
-                sb.append('<Tipo>' + id_code + '</Tipo>')
-                sb.append('<Numero>' + vat + '</Numero>')
-                sb.append('</Identificacion>')
+            sb.append('<Identificacion>')
+            sb.append('<Tipo>' + id_code + '</Tipo>')
+            sb.append('<Numero>' + vat + '</Numero>')
+            sb.append('</Identificacion>')
 
             if inv.tipo_documento != 'FEE':
                 if receiver_company.state_id and \

--- a/cr_electronic_invoice/models/res_partner.py
+++ b/cr_electronic_invoice/models/res_partner.py
@@ -104,15 +104,28 @@ class PartnerElectronic(models.Model):
             if json_response["status"] == 200:
                 activities = json_response["activities"]
                 # Activity Codes
+                economic_activities = self.env['economic.activity']
                 a_codes = list([])
                 for activity in activities:
                     if activity["estado"] == "A":
                         a_codes.append(activity["codigo"])
-                economic_activities = self.env['economic.activity'].with_context(active_test=False).search([('code',
-                                                                                                             'in',
-                                                                                                             a_codes)])
+                        economic_activity = self.env['economic.activity'].with_context(active_test=False).search([('code', '=', activity["codigo"])], limit=1)
+                        if not economic_activity:
+                            economic_activity = self.env['economic.activity'].create({
+                                'name': activity["descripcion"],
+                                'code': activity["codigo"],
+                                'description': activity["descripcion"],
+                                'sale_type': 'services' if activity["tipo"] == "S" else 'goods',
+                            })
+                        economic_activities += economic_activity
 
-                self.economic_activities_ids = economic_activities
+                
+                
+                if economic_activities:
+                    self.economic_activities_ids = economic_activities
+                else:
+                    self.economic_activities_ids = False
+
                 self.name = json_response["name"]
 
                 if len(a_codes) >= 1:

--- a/cr_electronic_invoice/wizard/account_payment_register.py
+++ b/cr_electronic_invoice/wizard/account_payment_register.py
@@ -11,51 +11,52 @@ class AccountPaymentRegister(models.TransientModel):
     def _create_payments(self):
         payment = super()._create_payments()
         
-        invoice = self.env["account.move"].browse(self._context.get("active_ids"))
+        invoices = self.env["account.move"].browse(self._context.get("active_ids"))
         
-        if invoice and payment.payment_type == 'inbound':
-            sucursal_id = payment.move_id.journal_id.sucursal or self.env.user.company_id.sucursal_MR  
-            terminal_id = payment.move_id.journal_id.terminal or self.env.user.company_id.terminal_MR    
-            sequence = self.env['ir.sequence'].next_by_code('sequence.REP')
-            payment.sequence = f"{sucursal_id}{terminal_id}{fe_enums.TipoDocumento['REP']}{sequence}"
-                
-            response_json = api_facturae.get_clave_hacienda(payment, 'REP', sequence, sucursal_id, terminal_id)
-            if response_json:
-                payment.clave = response_json.get('clave')
-                payment.sequence = response_json.get('consecutivo')
-                
-            if invoice.rep_string:
-                updated_rep_string_date = re.sub(r"<FechaEmision[^>]*>(.*?)</FechaEmision>",r"<FechaEmision>" + api_facturae.get_time_hacienda() + r"</FechaEmision>",invoice.rep_string)
-                updated_rep_string_clave = re.sub(r"<Clave[^>]*>(.*?)</Clave>",r"<Clave>" + payment.clave + r"</Clave>",updated_rep_string_date)
-                updated_rep_string_sequence = re.sub(r"<NumeroConsecutivo[^>]*>(.*?)</NumeroConsecutivo>",r"<NumeroConsecutivo>" + payment.sequence + r"</NumeroConsecutivo>",updated_rep_string_clave)
+        for invoice in invoices:
+            if invoice and payment.payment_type == 'inbound':
+                sucursal_id = payment.move_id.journal_id.sucursal or self.env.user.company_id.sucursal_MR  
+                terminal_id = payment.move_id.journal_id.terminal or self.env.user.company_id.terminal_MR    
+                sequence = self.env['ir.sequence'].next_by_code('sequence.REP')
+                payment.sequence = f"{sucursal_id}{terminal_id}{fe_enums.TipoDocumento['REP']}{sequence}"
+                    
+                response_json = api_facturae.get_clave_hacienda(payment, 'REP', sequence, sucursal_id, terminal_id)
+                if response_json:
+                    payment.clave = response_json.get('clave')
+                    payment.sequence = response_json.get('consecutivo')
+                    
+                if invoice.rep_string:
+                    updated_rep_string_date = re.sub(r"<FechaEmision[^>]*>(.*?)</FechaEmision>",r"<FechaEmision>" + api_facturae.get_time_hacienda() + r"</FechaEmision>",invoice.rep_string)
+                    updated_rep_string_clave = re.sub(r"<Clave[^>]*>(.*?)</Clave>",r"<Clave>" + payment.clave + r"</Clave>",updated_rep_string_date)
+                    updated_rep_string_sequence = re.sub(r"<NumeroConsecutivo[^>]*>(.*?)</NumeroConsecutivo>",r"<NumeroConsecutivo>" + payment.sequence + r"</NumeroConsecutivo>",updated_rep_string_clave)
 
-                xml_to_sign = str(updated_rep_string_sequence)
-                xml_firmado = api_facturae.sign_xml(invoice.company_id.signature, invoice.company_id.frm_pin, xml_to_sign)
-                payment.fname_xml_comprobante = f"REP_{response_json.get('clave')}.xml"
-                self.env['ir.attachment'].sudo().create({'name': payment.fname_xml_comprobante,
-                                                        'type': 'binary',
-                                                        'datas': base64.b64encode(xml_firmado),
-                                                        'res_model': 'account.payment',
-                                                        'res_id': payment.id,
-                                                        'res_field': 'xml_comprobante',
-                                                        'res_name': payment.fname_xml_comprobante,
-                                                        'mimetype': 'text/xml'})
- 
-                token_m_h = api_facturae.get_token_hacienda(invoice, invoice.company_id.frm_ws_ambiente)
-                send_xml_ = api_facturae.send_xml_rep(invoice, payment.clave, token_m_h, api_facturae.get_time_hacienda(), xml_firmado, invoice.company_id.frm_ws_ambiente)
-                response_json_consulta_clave = api_facturae.consulta_clave(payment.clave, token_m_h, invoice.company_id.frm_ws_ambiente)
-                estado_m_h = response_json_consulta_clave.get('ind-estado')
-                payment.state_tributacion = estado_m_h
+                    xml_to_sign = str(updated_rep_string_sequence)
+                    xml_firmado = api_facturae.sign_xml(invoice.company_id.signature, invoice.company_id.frm_pin, xml_to_sign)
+                    payment.fname_xml_comprobante = f"REP_{response_json.get('clave')}.xml"
+                    self.env['ir.attachment'].sudo().create({'name': payment.fname_xml_comprobante,
+                                                            'type': 'binary',
+                                                            'datas': base64.b64encode(xml_firmado),
+                                                            'res_model': 'account.payment',
+                                                            'res_id': payment.id,
+                                                            'res_field': 'xml_comprobante',
+                                                            'res_name': payment.fname_xml_comprobante,
+                                                            'mimetype': 'text/xml'})
+    
+                    token_m_h = api_facturae.get_token_hacienda(invoice, invoice.company_id.frm_ws_ambiente)
+                    send_xml_ = api_facturae.send_xml_rep(invoice, payment.clave, token_m_h, api_facturae.get_time_hacienda(), xml_firmado, invoice.company_id.frm_ws_ambiente)
+                    response_json_consulta_clave = api_facturae.consulta_clave(payment.clave, token_m_h, invoice.company_id.frm_ws_ambiente)
+                    estado_m_h = response_json_consulta_clave.get('ind-estado')
+                    payment.state_tributacion = estado_m_h
+                    
+                    if estado_m_h != 'procesando':
+                        payment.fname_xml_respuesta_tributacion = f"AHC_{payment.clave}.xml"
+                        self.env['ir.attachment'].create({'name': payment.fname_xml_respuesta_tributacion,
+                                                'type': 'binary',
+                                                'datas': response_json_consulta_clave.get('respuesta-xml'),
+                                                'res_model': 'account.payment',
+                                                'res_id': payment.id,
+                                                'res_field': 'xml_respuesta_tributacion',
+                                                'res_name': payment.fname_xml_respuesta_tributacion,
+                                                'mimetype': 'text/xml'})
                 
-                if estado_m_h != 'procesando':
-                    payment.fname_xml_respuesta_tributacion = f"AHC_{payment.clave}.xml"
-                    self.env['ir.attachment'].create({'name': payment.fname_xml_respuesta_tributacion,
-                                            'type': 'binary',
-                                            'datas': response_json_consulta_clave.get('respuesta-xml'),
-                                            'res_model': 'account.payment',
-                                            'res_id': payment.id,
-                                            'res_field': 'xml_respuesta_tributacion',
-                                            'res_name': payment.fname_xml_respuesta_tributacion,
-                                            'mimetype': 'text/xml'})
-             
         return payment

--- a/res_currency_cr_adapter/models/res_currency.py
+++ b/res_currency_cr_adapter/models/res_currency.py
@@ -265,3 +265,177 @@ class ResCurrencyRate(models.Model):
             'currency_id': currency_rate_obj.currency_id.id,
             'company_id': currency_rate_obj.company_id.id,
         })
+        
+        
+    @api.model
+    def _cron_update_usd(self, first_date=False, last_date=False):
+
+        _logger.info("=========================================================")
+        _logger.info("Executing exchange rate update from 1 CRC = X USD")
+
+        exchange_source = self.env['ir.config_parameter'].sudo().get_param('exchange_source')
+        if exchange_source == 'bccr':
+            _logger.info("Getting exchange rates from BCCR")
+            bccr_username = self.env['ir.config_parameter'].sudo().get_param('bccr_username')
+            bccr_email = self.env['ir.config_parameter'].sudo().get_param('bccr_email')
+            bccr_token = self.env['ir.config_parameter'].sudo().get_param('bccr_token')
+
+            # Get current date to get exchange rate for today
+            if first_date:
+                initial_date = datetime.strptime(first_date, "%Y-%m-%d").strftime('%d/%m/%Y')
+                end_date = datetime.strptime(last_date, "%Y-%m-%d").strftime('%d/%m/%Y')
+            else:
+                initial_date = datetime.now().date().strftime('%d/%m/%Y')
+                end_date = initial_date
+
+            # Web Service Connection using the XML schema from BCCRR
+            client = Client('https://gee.bccr.fi.cr/Indicadores/Suscripciones/WS/wsindicadoreseconomicos.asmx?WSDL')
+
+            response = client.service.ObtenerIndicadoresEconomicosXML(
+                Indicador='318', FechaInicio=initial_date, FechaFinal=end_date,
+                Nombre=bccr_username, SubNiveles='N', CorreoElectronico=bccr_email, Token=bccr_token)
+
+            xml_response = xml.etree.ElementTree.fromstring(response)
+            selling_rate_nodes = xml_response.findall("./INGC011_CAT_INDICADORECONOMIC")
+
+            # Get Buying exchange Rate from BCCR
+            response = client.service.ObtenerIndicadoresEconomicosXML(
+                Indicador='317', FechaInicio=initial_date, FechaFinal=end_date,
+                Nombre=bccr_username, SubNiveles='N', CorreoElectronico=bccr_email, Token=bccr_token)
+
+            xml_response = xml.etree.ElementTree.fromstring(response)
+            buying_rate_nodes = xml_response.findall("./INGC011_CAT_INDICADORECONOMIC")
+
+            selling_rate = 0
+            buying_rate = 0
+            node_index = 0
+            if len(selling_rate_nodes) > 0 and len(selling_rate_nodes) == len(buying_rate_nodes):
+                while node_index < len(selling_rate_nodes):
+                    if selling_rate_nodes[node_index].find("DES_FECHA").text == \
+                       buying_rate_nodes[node_index].find("DES_FECHA").text:
+                        current_date_str = datetime.strptime(selling_rate_nodes[node_index].find("DES_FECHA").text,
+                                                             "%Y-%m-%dT%H:%M:%S-06:00").strftime('%Y-%m-%d')
+
+                        selling_rate = float(selling_rate_nodes[node_index].find("NUM_VALOR").text)
+                        buying_rate = float(buying_rate_nodes[node_index].find("NUM_VALOR").text)
+
+                        # Odoo uses the value of 1 unit of the base currency divided between the exchage rate
+                        selling_original_rate = 1 / selling_rate
+                        buying_original_rate = 1 / buying_rate
+
+                        # GET THE CURRENCY ID
+                        currency_id = self.env['res.currency'].search([('name', '=', 'CRC')], limit=1)
+
+                        # Get the rate for this date to know it is already registered
+                        rates_ids = self.env['res.currency.rate'].search([('name', '=', current_date_str)], limit=1)
+
+                        if len(rates_ids) > 0:
+                            rates_ids.write(
+                                {'rate': selling_rate,
+                                 'original_rate': selling_original_rate,
+                                 'rate_2': buying_rate,
+                                 'original_rate_2': buying_original_rate,
+                                 'currency_id': currency_id.id}
+                                )
+                        else:
+                            self.create(
+                                {'name': current_date_str,
+                                 'rate': selling_rate,
+                                 'original_rate': selling_original_rate,
+                                 'rate_2': buying_rate,
+                                 'original_rate_2': buying_original_rate,
+                                 'currency_id': currency_id.id})
+
+                        _logger.info({'name': current_date_str,
+                                      'rate': selling_rate,
+                                      'original_rate': selling_original_rate,
+                                      'rate_2': buying_rate,
+                                      'original_rate_2': buying_original_rate,
+                                      'currency_id': currency_id.id})
+                    else:
+                        buy_des_fecha = buying_rate_nodes[node_index].find("DES_FECHA").text
+                        sell_des_fecha = selling_rate_nodes[node_index].find("DES_FECHA").text
+                        _logger.error("Error loading currency rates, dates for a buying (%s) ", buy_des_fecha)
+                        _logger.error("and selling (%s) rates don't match", sell_des_fecha)
+
+                    node_index += 1
+            else:
+                _logger.error("Error loading currency rates,dates range data for buying and selling rates don't match")
+
+        if exchange_source == 'hacienda':
+            _logger.info("Getting exchange rates from HACIENDA")
+
+            # Get current date to get exchange rate for today
+            if first_date:
+                initial_date = first_date.strftime('%Y-%m-%d')
+                end_date = last_date.strftime('%Y-%m-%d')
+
+                try:
+                    url = 'https://api.hacienda.go.cr/indicadores/tc/dolar/historico/?d='+initial_date+'&h='+end_date
+                    response = requests.get(url, timeout=5, verify=False)
+
+                except requests.exceptions.RequestException as e:
+                    _logger.error('RequestException %s', e)
+                    return False
+                if response.status_code in (200,):
+                    data = response.json()
+                    companies = self.env['res.company'].search([])
+                    for company in companies:
+                        _logger.error(company.id)
+
+                        for rate_line in data:
+                            today = datetime.strptime(rate_line['fecha'], '%Y-%m-%d %H:%M:%S')
+                            vals = {}
+                            vals['rate'] = rate_line['venta']
+                            # Odoo utiliza un valor inverso,
+                            # a cuantos dólares equivale 1 colón, por eso se divide 1 / tipo de cambio.
+                            vals['original_rate'] = 1 / vals['rate']
+                            vals['rate_2'] = rate_line['compra']
+                            vals['original_rate_2'] = 1 / vals['rate_2']
+                            vals['currency_id'] = self.env.ref('base.CRC').id
+
+                            rate_id = self.env['res.currency.rate'].search([('name', '=', today.date())], limit=1)
+
+                            if rate_id:
+                                rate_id.write(vals)
+                            else:
+                                vals['name'] = today.date()
+                                self.create(vals)
+            else:
+                try:
+                    url = 'https://api.hacienda.go.cr/indicadores/tc'
+                    response = requests.get(url, timeout=5, verify=False)
+
+                except requests.exceptions.RequestException as e:
+                    _logger.error('RequestException %s', e)
+                    return False
+
+                if response.status_code in (200,):
+                    # Save the exchange rate in database
+                    today = datetime.now().strftime('%Y-%m-%d')
+                    data = response.json()
+                    companies = self.env['res.company'].search([])
+                    for company in companies:
+                        _logger.error(company.id)
+                        vals = {}
+                        vals['rate'] = data['dolar']['venta']['valor']
+
+                        # Odoo utiliza un valor inverso,
+                        # a cuantos dólares equivale 1 colón, por eso se divide 1 / tipo de cambio.
+
+                        vals['original_rate'] = 1 / vals['rate']
+                        vals['rate_2'] = data['dolar']['compra']['valor']
+                        vals['original_rate_2'] = 1 / vals['rate_2']
+                        vals['currency_id'] = self.env.ref('base.CRC').id
+
+                        rate_id = self.env['res.currency.rate'].search([('name', '=', today)], limit=1)
+
+                        if rate_id:
+                            rate_id.write(vals)
+                        else:
+                            vals['name'] = today
+                            self.create(vals)
+
+                _logger.info(vals)
+
+        _logger.info("=========================================================")


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Identification field is required when receptor tag is present

Current behavior before PR:
FEE invoices are rejected

Desired behavior after PR is merged:
Accepted FEE invoices

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Always include receptor identification in XML and sanitize comments; auto-create missing economic activities; handle REP for multiple invoices and attach MH response; add cron to update USD/CRC exchange rates from BCCR/Hacienda.
> 
> - **Electronic Invoicing (`cr_electronic_invoice`)**:
>   - **XML Generation (`models/api_facturae.py`)**:
>     - Always include `<Identificacion>` inside `Receptor` (including for `FEE`).
>     - Sanitize `invoice_comments` using `tools.html2plaintext` before embedding in `<Otros>`.
>   - **Partner Activities (`models/res_partner.py`)**:
>     - On fetching activities, auto-create missing `economic.activity` records and assign them; set defaults accordingly.
>   - **REP Submission (`wizard/account_payment_register.py`)**:
>     - Process multiple selected invoices; generate/sign/send REP per invoice and attach Hacienda response when available.
> - **Currency Adapter (`res_currency_cr_adapter`)**:
>   - Add `_cron_update_usd` to update USD/CRC exchange rates via BCCR or Hacienda APIs and persist rates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08959f7e875d78d5f6607d95fcd7d77b08dcedd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->