### PR TITLE
Fix/fee receptor

### DIFF
--- a/cr_electronic_invoice/models/api_facturae.py
+++ b/cr_electronic_invoice/models/api_facturae.py
@@ -444,7 +444,7 @@ def gen_xml_v4_4(inv, sale_conditions, total_servicio_gravado,
         else:
             id_code = receiver_company.identification_id.code
 
-        if receiver_company.name:
+        if receiver_company.name and inv.tipo_documento != 'FEE':
             sb.append('<Receptor>')
             sb.append('<Nombre>' + escape(str(receiver_company.name[:99])) + '</Nombre>')
 

--- a/cr_electronic_invoice/models/api_facturae.py
+++ b/cr_electronic_invoice/models/api_facturae.py
@@ -444,15 +444,13 @@ def gen_xml_v4_4(inv, sale_conditions, total_servicio_gravado,
         else:
             id_code = receiver_company.identification_id.code
 
-        if receiver_company.name and inv.tipo_documento != 'FEE':
+        if receiver_company.name:
             sb.append('<Receptor>')
             sb.append('<Nombre>' + escape(str(receiver_company.name[:99])) + '</Nombre>')
-
-            if not (inv.tipo_documento == 'FEE' or id_code == '05'):
-                sb.append('<Identificacion>')
-                sb.append('<Tipo>' + id_code + '</Tipo>')
-                sb.append('<Numero>' + vat + '</Numero>')
-                sb.append('</Identificacion>')
+            sb.append('<Identificacion>')
+            sb.append('<Tipo>' + id_code + '</Tipo>')
+            sb.append('<Numero>' + vat + '</Numero>')
+            sb.append('</Identificacion>')
 
             if inv.tipo_documento != 'FEE':
                 if receiver_company.state_id and \


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Identification field is required when receptor tag is present

Current behavior before PR:
FEE invoices are rejected

Desired behavior after PR is merged:
Accepted FEE invoices

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Always adds the receptor `Identificacion` block in XML generation, including for FEE documents.
> 
> - **XML generation (`cr_electronic_invoice/models/api_facturae.py`)**
>   - In `gen_xml_v4_4`, within `<Receptor>`, unconditionally appends `<Identificacion>` (`<Tipo>`, `<Numero>`) by removing the conditional that skipped it for `FEE` or `id_code == '05'`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08959f7e875d78d5f6607d95fcd7d77b08dcedd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->