### PR TITLE
fix: Update reference document name for Regimen Simplificado

### DIFF
--- a/cr_electronic_invoice/data/reference_document_data.xml
+++ b/cr_electronic_invoice/data/reference_document_data.xml
@@ -82,7 +82,7 @@
 
     <record id="cr_electronic_invoice.ReferenceDocument_14" model="reference.document">
         <field name="code">14</field>
-        <field name="name">Comprobante aportado por contribuyente del Regimen Especial</field>
+        <field name="name">Comprobante aportado por contribuyente del Regimen Simplificado</field>
         <field name="active">true</field>
     </record>
 


### PR DESCRIPTION
- Changed the name of the reference document from "Regimen Especial" to "Regimen Simplificado" in the XML data file.