### PR TITLE
Feat/exoneration required form

### DIFF
--- a/cr_electronic_invoice/data/reference_document_data.xml
+++ b/cr_electronic_invoice/data/reference_document_data.xml
@@ -82,7 +82,7 @@
 
     <record id="cr_electronic_invoice.ReferenceDocument_14" model="reference.document">
         <field name="code">14</field>
-        <field name="name">Comprobante aportado por contribuyente del Regimen Especial</field>
+        <field name="name">Comprobante aportado por contribuyente del Regimen Simplificado</field>
         <field name="active">true</field>
     </record>
 

--- a/cr_electronic_invoice/models/account_move.py
+++ b/cr_electronic_invoice/models/account_move.py
@@ -157,6 +157,21 @@ class AccountInvoiceElectronic(models.Model):
     economic_activities_ids = fields.Many2many('economic.activity', string='Economic activities',
                                                compute='_compute_economic_activities', context={'active_test': False})
 
+    # Mostrar formulario de exoneración del partner cuando fiscal_position_id = Exonerado 13%
+    show_exoneration = fields.Boolean(
+        string="Show Exoneration",
+        compute="_compute_show_exoneration",
+    )
+    # Campos relacionados al partner: se muestran y editan en la factura, los datos viven en res.partner
+    exoneration_number = fields.Char(related="partner_id.exoneration_number", string="Exoneration Number", readonly=False)
+    type_exoneration = fields.Many2one("aut.ex", related="partner_id.type_exoneration", string="Authorization Type", readonly=False)
+    exoneration_issuer = fields.Many2one("issuer.ex", related="partner_id.exoneration_issuer", string="Exoneration Issuer", readonly=False)
+    percentage_exoneration = fields.Float(related="partner_id.percentage_exoneration", string="Percentage of VAT Exoneration", readonly=False)
+    date_issue = fields.Date(related="partner_id.date_issue", string="Issue Date", readonly=False)
+    date_expiration = fields.Date(related="partner_id.date_expiration", string="Expiration Date", readonly=False)
+    exoneration_article = fields.Char(related="partner_id.exoneration_article", string="Exoneration Article", readonly=False)
+    exoneration_clause = fields.Char(related="partner_id.exoneration_clause", string="Exoneration Clause", readonly=False)
+
     not_loaded_invoice = fields.Char(string='Original Invoice Number not loaded', readonly=True)
 
     not_loaded_invoice_date = fields.Date(string='Original Invoice Date not loaded', readonly=True)
@@ -214,6 +229,15 @@ class AccountInvoiceElectronic(models.Model):
         # base_url = self.env['ir.config_parameter'].sudo().get_param('web.base.url')
         # self.qr_image_attachment = f'{base_url}/web/image/{attachment.id}'
         # self.qr_image = qr_bytes
+
+    @api.depends("fiscal_position_id", "fiscal_position_id.name", "move_type")
+    def _compute_show_exoneration(self):
+        for inv in self:
+            inv.show_exoneration = (
+                inv.move_type in ("out_invoice", "out_refund")
+                and bool(inv.fiscal_position_id)
+                and inv.fiscal_position_id.name == "Exonerado 13%"
+            )
 
     @api.onchange('partner_id', 'company_id')
     def _compute_economic_activities(self):
@@ -1464,10 +1488,32 @@ class AccountInvoiceElectronic(models.Model):
                 if inv.state == 'draft':
                     super(AccountInvoiceElectronic, inv).action_post()
                     continue
-            
-            if inv.partner_id.has_exoneration and inv.partner_id.date_expiration and \
-                (inv.partner_id.date_expiration < datetime.date.today()):
-                    raise UserError(_('The exoneration of this client has expired'))
+
+            if inv.show_exoneration:
+                p = inv.partner_id
+                missing = []
+                if not p.exoneration_number:
+                    missing.append(_("Exoneration Number"))
+                if not p.type_exoneration:
+                    missing.append(_("Authorization Type"))
+                if not p.exoneration_issuer:
+                    missing.append(_("Exoneration Issuer"))
+                if p.percentage_exoneration is False or p.percentage_exoneration is None:
+                    missing.append(_("Percentage of VAT Exoneration"))
+                if not p.date_issue:
+                    missing.append(_("Issue Date"))
+                if not p.date_expiration:
+                    missing.append(_("Expiration Date"))
+                if missing:
+                    raise UserError(
+                        _('With fiscal position "Exonerado 13%%" the following customer fields are required: %s')
+                        % ", ".join(missing)
+                    )
+                if p.date_expiration < datetime.date.today():
+                    raise UserError(_("The exoneration of this client has expired"))
+            elif inv.partner_id.has_exoneration and inv.partner_id.date_expiration and \
+                    (inv.partner_id.date_expiration < datetime.date.today()):
+                raise UserError(_('The exoneration of this client has expired'))
 
             currency = inv.currency_id
             sequence = False

--- a/cr_electronic_invoice/models/account_move.py
+++ b/cr_electronic_invoice/models/account_move.py
@@ -1579,14 +1579,17 @@ class AccountInvoiceElectronic(models.Model):
             inv.invoice_amount_text = extensions.text_converter.number_to_text_es(inv.amount_total)
 
     def get_amount_total_words(self, amount, export=False):
+        amount_int = ("%.2f" %amount).split(".", 1)[0]
+        amount_cents = ("%.2f" %amount).split(".", 1)[1]
+        amount_int = int(amount_int)
         if export:
-            return num2words(amount, lang='en').title() + " " + self.currency_id.currency_unit_label
+            return num2words(amount_int, lang='en').title() + (" and %s/100 %s" % (amount_cents, self.currency_id.currency_unit_label))
         else:
             if self.currency_id.currency_unit_label == 'Dollars':
                 currency_unit_label = 'Dólares'
             else:
                 currency_unit_label = 'Colones'
-            return num2words(amount, lang='es').title() + " " + currency_unit_label
+            return num2words(amount_int, lang='es').title() + (" y %s/100 %s" % (amount_cents, currency_unit_label))
 
     def _reverse_move_vals(self, default_values, cancel=True):
         move_vals = super()._reverse_move_vals(default_values, cancel)

--- a/cr_electronic_invoice/models/account_move.py
+++ b/cr_electronic_invoice/models/account_move.py
@@ -11,6 +11,7 @@ from odoo.tools.misc import get_lang
 from odoo.http import request
 from .qr_generator import GenerateQrCode
 from odoo.tools import html2plaintext
+from num2words import num2words
 
 from . import api_facturae
 from .. import extensions
@@ -174,42 +175,45 @@ class AccountInvoiceElectronic(models.Model):
     rep_string = fields.Text()
 
     def _compute_qr_code(self):
-        qr_info = ''
-        if self.env.user.company_id.invoice_qr_type != 'by_info':
-            qr_info = request.env['ir.config_parameter'].sudo().get_param('web.base.url')
-            qr_info += self.get_portal_url()
-        else:
-            if self.env.user.company_id.invoice_field_ids:
-                # F841 local variable 'result' is assigned to but never used
-                # result = self.search_read([('id', 'in', self.ids)],
-                # self.env.user.company_id.invoice_field_ids.mapped('field_id.name'))
-                dict_result = {}
-                for ffild in self.env.user.company_id.invoice_field_ids.mapped('field_id'):
-                    if ffild.ttype == 'many2one':
-                        dict_result[ffild.field_description] = self[ffild.name].display_name
-                    else:
-                        dict_result[ffild.field_description] = self[ffild.name]
-                for key, value in dict_result.items():
-                    if str(key).__contains__('Partner') or str(key).__contains__(_('Partner')):
-                        if self.move_type in ['out_invoice', 'out_refund']:
-                            key = str(key).replace(_('Partner'), _('Customer'))
-                        elif self.move_type in ['in_invoice', 'in_refund']:
-                            key = str(key).replace(_('Partner'), _('Vendor'))
-                    qr_info += f"{key} : {value} <br/>"
-                qr_info = html2plaintext(qr_info)
+        for record in self:
+            qr_info = ''
+            if self.env.user.company_id.invoice_qr_type != 'by_info':
+                qr_info = request.env['ir.config_parameter'].sudo().get_param('web.base.url')
+                qr_info += record.get_portal_url()
+            else:
+                if self.env.user.company_id.invoice_field_ids:
+                    # F841 local variable 'result' is assigned to but never used
+                    # result = self.search_read([('id', 'in', self.ids)],
+                    # self.env.user.company_id.invoice_field_ids.mapped('field_id.name'))
+                    dict_result = {}
+                    for ffild in self.env.user.company_id.invoice_field_ids.mapped('field_id'):
+                        if ffild.ttype == 'many2one':
+                            dict_result[ffild.field_description] = self[ffild.name].display_name
+                        else:
+                            dict_result[ffild.field_description] = self[ffild.name]
+                    for key, value in dict_result.items():
+                        if str(key).__contains__('Partner') or str(key).__contains__(_('Partner')):
+                            if record.move_type in ['out_invoice', 'out_refund']:
+                                key = str(key).replace(_('Partner'), _('Customer'))
+                            elif record.move_type in ['in_invoice', 'in_refund']:
+                                key = str(key).replace(_('Partner'), _('Vendor'))
+                        qr_info += f"{key} : {value} <br/>"
+                    qr_info = html2plaintext(qr_info)
+            record.qr_image = GenerateQrCode.generate_qr_code(qr_info)
 
-        qr_bytes = GenerateQrCode.generate_qr_code(qr_info)
-        attachment = self.env['ir.attachment'].create({
-            'name': f"qr_{self.id}.png",
-            'type': 'binary',
-            'datas': qr_bytes,
-            'res_model': False,
-            'res_id': False,
-            'mimetype': 'image/png',
-        })
-        base_url = self.env['ir.config_parameter'].sudo().get_param('web.base.url')
-        self.qr_image_attachment = f'{base_url}/web/image/{attachment.id}'
-        self.qr_image = qr_bytes
+
+        # qr_bytes = GenerateQrCode.generate_qr_code(qr_info)
+        # attachment = self.env['ir.attachment'].create({
+        #     'name': f"qr_{self.id}.png",
+        #     'type': 'binary',
+        #     'datas': qr_bytes,
+        #     'res_model': False,
+        #     'res_id': False,
+        #     'mimetype': 'image/png',
+        # })
+        # base_url = self.env['ir.config_parameter'].sudo().get_param('web.base.url')
+        # self.qr_image_attachment = f'{base_url}/web/image/{attachment.id}'
+        # self.qr_image = qr_bytes
 
     @api.onchange('partner_id', 'company_id')
     def _compute_economic_activities(self):
@@ -1573,6 +1577,16 @@ class AccountInvoiceElectronic(models.Model):
     def update_text_amount(self):
         for inv in self:
             inv.invoice_amount_text = extensions.text_converter.number_to_text_es(inv.amount_total)
+
+    def get_amount_total_words(self, amount, export=False):
+        if export:
+            return num2words(amount, lang='en').title() + " " + self.currency_id.currency_unit_label
+        else:
+            if self.currency_id.currency_unit_label == 'Dollars':
+                currency_unit_label = 'Dólares'
+            else:
+                currency_unit_label = 'Colones'
+            return num2words(amount, lang='es').title() + " " + currency_unit_label
 
     def _reverse_move_vals(self, default_values, cancel=True):
         move_vals = super()._reverse_move_vals(default_values, cancel)

--- a/cr_electronic_invoice/models/api_facturae.py
+++ b/cr_electronic_invoice/models/api_facturae.py
@@ -267,9 +267,9 @@ def gen_xml_mr_4_4(clave, cedula_emisor, fecha_emision, id_mensaje,
 
     # '''Obtenemos el número de identificación del Emisor y lo validamos númericamente'''
     mr_cedula_emisor = re.sub('[^0-9]', '', cedula_emisor)
-    if len(mr_cedula_emisor) != 12:
-        mr_cedula_emisor = str(mr_cedula_emisor).zfill(12)
-    elif mr_cedula_emisor is None:
+    # if len(mr_cedula_emisor) != 12:
+    #     mr_cedula_emisor = str(mr_cedula_emisor).zfill(12)
+    if mr_cedula_emisor is None:
         raise UserError(_('La cédula del Emisor en el MR es inválida.'))
 
     mr_fecha_emision = fecha_emision
@@ -284,9 +284,9 @@ def gen_xml_mr_4_4(clave, cedula_emisor, fecha_emision, id_mensaje,
         raise UserError(_('No se ha proporcionado un ID válido para el MR.'))
 
     mr_cedula_receptor = re.sub('[^0-9]', '', cedula_receptor)
-    if len(mr_cedula_receptor) != 12:
-        mr_cedula_receptor = str(mr_cedula_receptor).zfill(12)
-    elif mr_cedula_receptor is None:
+    # if len(mr_cedula_receptor) != 12:
+    #     mr_cedula_receptor = str(mr_cedula_receptor).zfill(12)
+    if mr_cedula_receptor is None:
         raise UserError(_('No se ha proporcionado una cédula de receptor válida para el MR.'))
 
     # '''Verificamos si el consecutivo indicado para el mensaje receptor corresponde a numeros'''

--- a/cr_electronic_invoice/views/account_move_views.xml
+++ b/cr_electronic_invoice/views/account_move_views.xml
@@ -39,6 +39,7 @@
             <field name="partner_id" position="after">
                 <field name="economic_activities_ids" invisible="1" readonly="1" options='{"active_test": [("type","in", ("in_invoice", "in_refund"))]}'/>
                 <field name="economic_activity_id" attrs="{'required':[('move_type','in', ('out_invoice', 'out_refund'))],'invisible':[('move_type','not in', ('out_invoice', 'out_refund')), ('tipo_documento','!=', 'FEC')]}" domain="[('id', 'in', economic_activities_ids),]" options='{"no_open": True, "no_create": True, "active_test": [("type","in", ("in_invoice", "in_refund"))]}'/>
+                <field name="show_exoneration" invisible="1"/>
                 <field name="number_electronic" readonly="1" attrs="{'invisible':[('move_type','not in', ('out_invoice', 'out_refund','in_invoice', 'in_refund'))]}"/>
                 <field name="sequence" readonly="1" attrs="{'invisible':[('move_type','not in', ('out_invoice', 'out_refund','in_invoice', 'in_refund'))]}"/>
             </field>
@@ -101,6 +102,21 @@
                             </group>
                         </group>
 
+                    </group>
+                </page>
+            </xpath>
+
+            <xpath expr="//page[@name='fe_invoice_data']" position="after">
+                <page name="exoneration" string="Exoneration" attrs="{'invisible': [('show_exoneration', '=', False)]}">
+                    <group col="2">
+                        <field name="exoneration_number" attrs="{'required': [('show_exoneration', '=', True)]}"/>
+                        <field name="type_exoneration" attrs="{'required': [('show_exoneration', '=', True)]}"/>
+                        <field name="exoneration_issuer" attrs="{'required': [('show_exoneration', '=', True)]}"/>
+                        <field name="percentage_exoneration" attrs="{'required': [('show_exoneration', '=', True)]}"/>
+                        <field name="date_issue" attrs="{'required': [('show_exoneration', '=', True)]}"/>
+                        <field name="date_expiration" attrs="{'required': [('show_exoneration', '=', True)]}"/>
+                        <field name="exoneration_article"/>
+                        <field name="exoneration_clause"/>
                     </group>
                 </page>
             </xpath>

--- a/cr_electronic_invoice/views/report_invoice_document.xml
+++ b/cr_electronic_invoice/views/report_invoice_document.xml
@@ -244,6 +244,7 @@
                     </div>
                     <p>
                       <span>Autorizada mediante resolución N° DGT-R-033-2019 del 20 de junio de 2019.</span>
+                      <!-- <span>Autorizado mediante resolución Nº MH-DGT-RES-0027-2024 del 13 de noviembre de 2024.</span> -->
                     </p>
 
                     <div style="width:700px; height:110px;">

--- a/cr_electronic_invoice_qweb_fe/views/report_sales_invoice_qweb.xml
+++ b/cr_electronic_invoice_qweb_fe/views/report_sales_invoice_qweb.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="1">
 
-    <template id="sale.report_invoice_document_inherit_sale" inherit_id="account.report_invoice_document">
+    <template id="report_invoice_document_inherit_sale" inherit_id="account.report_invoice_document">
     </template>
 
-    <template id="sale_stock.sale_stock_report_invoice_document" inherit_id="account.report_invoice_document">
+    <template id="report_invoice_document_inherit_sale_stock" inherit_id="account.report_invoice_document">
     </template>
     <template id="account.report_invoice_document">
         <div class="article" t-att-data-oe-model="o and o._name" t-att-data-oe-id="o and o.id" t-att-data-oe-lang="o and o.env.context.get('lang')">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new validation gates to `account.move.action_post` and new UI fields, which can block posting customer invoices if partner exoneration data is incomplete or misconfigured. Also tweaks MR XML ID normalization behavior, which could affect Hacienda message acceptance for some ID formats.
> 
> **Overview**
> **Adds an exoneration workflow to customer invoices/credit notes.** When `fiscal_position_id` is *"Exonerado 13%"*, invoices now compute `show_exoneration`, expose partner exoneration fields directly on the invoice (editable related fields), and show a new **Exoneration** tab in the form view.
> 
> **Tightens posting validation.** `action_post` now requires specific exoneration fields to be filled (and not expired) when `show_exoneration` is true, with a clearer error listing missing fields.
> 
> Also updates reference document code `14` label, renames two QWeb template IDs for invoices, and stops zero-padding emitter/receiver IDs to 12 digits in MR XML generation (`gen_xml_mr_4_4`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f96c91608cc0c1d9928c6c296d2b8fd54232040. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->