### PR TITLE
feat: Add exoneration form with required fields validation for Exonerado 13% fiscal position

### DIFF
--- a/cr_electronic_invoice/models/account_move.py
+++ b/cr_electronic_invoice/models/account_move.py
@@ -157,6 +157,21 @@ class AccountInvoiceElectronic(models.Model):
     economic_activities_ids = fields.Many2many('economic.activity', string='Economic activities',
                                                compute='_compute_economic_activities', context={'active_test': False})
 
+    # Mostrar formulario de exoneración del partner cuando fiscal_position_id = Exonerado 13%
+    show_exoneration = fields.Boolean(
+        string="Show Exoneration",
+        compute="_compute_show_exoneration",
+    )
+    # Campos relacionados al partner: se muestran y editan en la factura, los datos viven en res.partner
+    exoneration_number = fields.Char(related="partner_id.exoneration_number", string="Exoneration Number", readonly=False)
+    type_exoneration = fields.Many2one("aut.ex", related="partner_id.type_exoneration", string="Authorization Type", readonly=False)
+    exoneration_issuer = fields.Many2one("issuer.ex", related="partner_id.exoneration_issuer", string="Exoneration Issuer", readonly=False)
+    percentage_exoneration = fields.Float(related="partner_id.percentage_exoneration", string="Percentage of VAT Exoneration", readonly=False)
+    date_issue = fields.Date(related="partner_id.date_issue", string="Issue Date", readonly=False)
+    date_expiration = fields.Date(related="partner_id.date_expiration", string="Expiration Date", readonly=False)
+    exoneration_article = fields.Char(related="partner_id.exoneration_article", string="Exoneration Article", readonly=False)
+    exoneration_clause = fields.Char(related="partner_id.exoneration_clause", string="Exoneration Clause", readonly=False)
+
     not_loaded_invoice = fields.Char(string='Original Invoice Number not loaded', readonly=True)
 
     not_loaded_invoice_date = fields.Date(string='Original Invoice Date not loaded', readonly=True)
@@ -214,6 +229,15 @@ class AccountInvoiceElectronic(models.Model):
         # base_url = self.env['ir.config_parameter'].sudo().get_param('web.base.url')
         # self.qr_image_attachment = f'{base_url}/web/image/{attachment.id}'
         # self.qr_image = qr_bytes
+
+    @api.depends("fiscal_position_id", "fiscal_position_id.name", "move_type")
+    def _compute_show_exoneration(self):
+        for inv in self:
+            inv.show_exoneration = (
+                inv.move_type in ("out_invoice", "out_refund")
+                and bool(inv.fiscal_position_id)
+                and inv.fiscal_position_id.name == "Exonerado 13%"
+            )
 
     @api.onchange('partner_id', 'company_id')
     def _compute_economic_activities(self):
@@ -1465,9 +1489,31 @@ class AccountInvoiceElectronic(models.Model):
                     super(AccountInvoiceElectronic, inv).action_post()
                     continue
             
-            if inv.partner_id.has_exoneration and inv.partner_id.date_expiration and \
-                (inv.partner_id.date_expiration < datetime.date.today()):
-                    raise UserError(_('The exoneration of this client has expired'))
+            if inv.show_exoneration:
+                p = inv.partner_id
+                missing = []
+                if not p.exoneration_number:
+                    missing.append(_("Exoneration Number"))
+                if not p.type_exoneration:
+                    missing.append(_("Authorization Type"))
+                if not p.exoneration_issuer:
+                    missing.append(_("Exoneration Issuer"))
+                if not p.percentage_exoneration:
+                    missing.append(_("Percentage of VAT Exoneration"))
+                if not p.date_issue:
+                    missing.append(_("Issue Date"))
+                if not p.date_expiration:
+                    missing.append(_("Expiration Date"))
+                if missing:
+                    raise UserError(
+                        _('With fiscal position "Exonerado 13%%" the following customer fields are required: %s')
+                        % ", ".join(missing)
+                    )
+                if p.date_expiration < datetime.date.today():
+                    raise UserError(_("The exoneration of this client has expired"))
+            elif inv.partner_id.has_exoneration and inv.partner_id.date_expiration and \
+                    (inv.partner_id.date_expiration < datetime.date.today()):
+                raise UserError(_('The exoneration of this client has expired'))
 
             currency = inv.currency_id
             sequence = False

--- a/cr_electronic_invoice/views/account_move_views.xml
+++ b/cr_electronic_invoice/views/account_move_views.xml
@@ -39,6 +39,7 @@
             <field name="partner_id" position="after">
                 <field name="economic_activities_ids" invisible="1" readonly="1" options='{"active_test": [("type","in", ("in_invoice", "in_refund"))]}'/>
                 <field name="economic_activity_id" attrs="{'required':[('move_type','in', ('out_invoice', 'out_refund'))],'invisible':[('move_type','not in', ('out_invoice', 'out_refund')), ('tipo_documento','!=', 'FEC')]}" domain="[('id', 'in', economic_activities_ids),]" options='{"no_open": True, "no_create": True, "active_test": [("type","in", ("in_invoice", "in_refund"))]}'/>
+                <field name="show_exoneration" invisible="1"/>
                 <field name="number_electronic" readonly="1" attrs="{'invisible':[('move_type','not in', ('out_invoice', 'out_refund','in_invoice', 'in_refund'))]}"/>
                 <field name="sequence" readonly="1" attrs="{'invisible':[('move_type','not in', ('out_invoice', 'out_refund','in_invoice', 'in_refund'))]}"/>
             </field>
@@ -101,6 +102,21 @@
                             </group>
                         </group>
 
+                    </group>
+                </page>
+            </xpath>
+
+            <xpath expr="//page[@name='fe_invoice_data']" position="after">
+                <page name="exoneration" string="Exoneration" attrs="{'invisible': [('show_exoneration', '=', False)]}">
+                    <group col="2">
+                        <field name="exoneration_number" attrs="{'required': [('show_exoneration', '=', True)]}"/>
+                        <field name="type_exoneration" attrs="{'required': [('show_exoneration', '=', True)]}"/>
+                        <field name="exoneration_issuer" attrs="{'required': [('show_exoneration', '=', True)]}"/>
+                        <field name="percentage_exoneration" attrs="{'required': [('show_exoneration', '=', True)]}"/>
+                        <field name="date_issue" attrs="{'required': [('show_exoneration', '=', True)]}"/>
+                        <field name="date_expiration" attrs="{'required': [('show_exoneration', '=', True)]}"/>
+                        <field name="exoneration_article"/>
+                        <field name="exoneration_clause"/>
                     </group>
                 </page>
             </xpath>


### PR DESCRIPTION
## Changes
- Adds 'Exoneration' tab on invoices when fiscal position is 'Exonerado 13%'
- Required fields enforced on invoice confirmation: number, type, issuer, percentage, dates
- Fixes percentage_exoneration validation (was checking is False/None, now uses not)
- Keeps original Qweb template IDs (no renaming)
- Fixes workflow: branch created cleanly from 16.0 following README guidelines

## Modified files
- cr_electronic_invoice/models/account_move.py
- cr_electronic_invoice/views/account_move_views.xml

## Tested on
- Local ✅

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes invoice posting validation and can block `action_post` for customer invoices/refunds when fiscal position is `Exonerado 13%` if partner exoneration data is missing or expired.
> 
> **Overview**
> Adds an **invoice-level Exoneration workflow** for customer invoices/refunds when the fiscal position name is `Exonerado 13%`.
> 
> The invoice form now conditionally shows a new *Exoneration* tab (backed by related `res.partner` fields) and `action_post` enforces that the exoneration number/type/issuer/percentage and issue/expiration dates are present, plus rejects posting when the exoneration is expired.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a6eb40b32193274ebf77e41225576f98786c5e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->