### PR TITLE
fix: Add missing else branch and @api.depends in _compute_economic_activities

### DIFF
--- a/cr_electronic_invoice/models/account_move.py
+++ b/cr_electronic_invoice/models/account_move.py
@@ -250,8 +250,9 @@ class AccountInvoiceElectronic(models.Model):
                     inv.economic_activity_id = inv.partner_id.activity_id
                 else:
                     inv.economic_activities_ids = self.env['economic.activity'].browse()
+                    inv.economic_activity_id = False
             else:
-                inv.economic_activities_ids = self.env['economic.activity'].search([('active', '=', False)])
+                inv.economic_activities_ids = self.env['economic.activity'].browse()
                 inv.economic_activity_id = inv.company_id.activity_id
 
     @api.onchange('partner_id')

--- a/cr_electronic_invoice/models/account_move.py
+++ b/cr_electronic_invoice/models/account_move.py
@@ -241,13 +241,15 @@ class AccountInvoiceElectronic(models.Model):
                 and inv.fiscal_position_id.name == EXONERATION_FISCAL_POSITION
             )
 
-    @api.onchange('partner_id', 'company_id')
+    @api.depends('partner_id', 'company_id', 'move_type')
     def _compute_economic_activities(self):
         for inv in self:
             if inv.move_type in ('in_invoice', 'in_refund'):
                 if inv.partner_id:
                     inv.economic_activities_ids = inv.partner_id.economic_activities_ids
                     inv.economic_activity_id = inv.partner_id.activity_id
+                else:
+                    inv.economic_activities_ids = self.env['economic.activity'].browse()
             else:
                 inv.economic_activities_ids = self.env['economic.activity'].search([('active', '=', False)])
                 inv.economic_activity_id = inv.company_id.activity_id


### PR DESCRIPTION
## Summary
- Changes `@api.onchange` to `@api.depends` on `_compute_economic_activities` for correct compute field behavior
- Adds missing `else` branch for `in_invoice`/`in_refund` records without a partner, preventing `CacheMiss` / `ValueError: Compute method failed to assign`

## Test plan
- [ ] Upload a vendor bill XML — verify no errors on load
- [ ] Open a new vendor bill without a partner — verify form loads without errors
- [ ] Set a partner on a vendor bill — verify economic activities populate correctly