### PR TITLE
[FIX] cr_electronic_invoice: fix FEC send - OpenSSL pkcs12 removal and invoice line crash

### DIFF
--- a/cr_electronic_invoice/models/account_move.py
+++ b/cr_electronic_invoice/models/account_move.py
@@ -1129,11 +1129,7 @@ class AccountInvoiceElectronic(models.Model):
 
                             subtotal_line = round(base_line - descuento, 5)
 
-                            # Corregir error cuando un producto trae en el nombre "", por ejemplo: "disco duro"
-                            # Esto no debería suceder, pero, si sucede, lo corregimos
-                            if inv_line.name[:156].find('"'):
-                                detalle_linea = inv_line.name[:160].replace(
-                                    '"', '')
+                            detalle_linea = (inv_line.name or '')[:160].replace('"', '')
 
                             line = {
                                 "cantidad": quantity,

--- a/cr_electronic_invoice/models/api_facturae.py
+++ b/cr_electronic_invoice/models/api_facturae.py
@@ -11,8 +11,6 @@ import pytz
 import time
 import phonenumbers
 import random
-from cryptography import x509
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.serialization import pkcs12 as crypto_pkcs12
 
 from odoo import _, tools
@@ -22,10 +20,6 @@ from ..xades.context2 import XAdESContext2, PolicyId2, create_xades_epes_signatu
 
 from lxml import etree
 
-try:
-    from OpenSSL import crypto
-except(ImportError, IOError) as err:
-    logging.info(err)
 
 # PARA VALIDAR JSON DE RESPUESTA
 # from .. import extensions
@@ -1425,11 +1419,8 @@ def load_xml_data(invoice, load_lines, account_id, product_id=False, analytic_ac
 
 
 def p12_expiration_date(p12file, password):
-    try:
-        _password = password.encode() if isinstance(password, str) else password
-        _, cert, _ = crypto_pkcs12.load_key_and_certificates(
-            base64.b64decode(p12file), _password
-        )
-        return cert.not_valid_after
-    except Exception as crypte:
-        raise
+    _password = password.encode() if isinstance(password, str) else password
+    _, cert, _ = crypto_pkcs12.load_key_and_certificates(
+        base64.b64decode(p12file), _password
+    )
+    return cert.not_valid_after

--- a/cr_electronic_invoice/models/api_facturae.py
+++ b/cr_electronic_invoice/models/api_facturae.py
@@ -13,6 +13,7 @@ import phonenumbers
 import random
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.serialization import pkcs12 as crypto_pkcs12
 
 from odoo import _, tools
 from odoo.exceptions import UserError
@@ -42,8 +43,13 @@ def sign_xml(cert, password, xml, policy_id='https://www.hacienda.go.cr/ATV/Comp
 
     root.append(signature)
     ctx = XAdESContext2(policy)
-    certificate = crypto.load_pkcs12(base64.b64decode(cert), password)
-    ctx.load_pkcs12(certificate)
+    _password = password.encode() if isinstance(password, str) else password
+    private_key, certificate, _ = crypto_pkcs12.load_key_and_certificates(
+        base64.b64decode(cert), _password
+    )
+    ctx.x509 = certificate
+    ctx.public_key = certificate.public_key()
+    ctx.private_key = private_key
     ctx.sign(signature)
 
     return etree.tostring(root, encoding='UTF-8', method='xml', xml_declaration=True, with_tail=False)
@@ -1420,12 +1426,10 @@ def load_xml_data(invoice, load_lines, account_id, product_id=False, analytic_ac
 
 def p12_expiration_date(p12file, password):
     try:
-        pkcs12 = crypto.load_pkcs12(base64.b64decode(p12file), password)
-        data = crypto.dump_certificate(crypto.FILETYPE_PEM, pkcs12.get_certificate())
-        cert = x509.load_pem_x509_certificate(data, default_backend())
+        _password = password.encode() if isinstance(password, str) else password
+        _, cert, _ = crypto_pkcs12.load_key_and_certificates(
+            base64.b64decode(p12file), _password
+        )
         return cert.not_valid_after
-    except crypto.Error as crypte:
-        exc_str = str(crypte)
-        if exc_str.find('mac verify failure'):
-            raise
+    except Exception as crypte:
         raise


### PR DESCRIPTION
## Summary

- Replace `OpenSSL.crypto.load_pkcs12` (removed in pyOpenSSL 25.x) with `cryptography.hazmat.primitives.serialization.pkcs12.load_key_and_certificates()` in `sign_xml` and `p12_expiration_date` — fixes `AttributeError: module 'OpenSSL.crypto' has no attribute 'load_pkcs12'` when clicking **Send FEC** on non-domiciled vendor bills
- Fix `TypeError: 'bool' object is not subscriptable` in FEC line detail generation when an invoice line has no description (`name` is `False`) — simplified to `(inv_line.name or '')[:160].replace('"', '')` which also corrects an inverted `find()` condition in the original code

## Test plan

- [ ] Open a non-domiciled vendor bill (voucher type: Factura Electrónica de Compra)
- [ ] Click **Send FEC** — confirm no `AttributeError` related to `load_pkcs12`
- [ ] Verify the bill reaches **Accepted** status in Hacienda (chatter shows confirmation)
- [ ] Test with an invoice line that has no product description — confirm no `TypeError`
- [ ] Test with an invoice line whose description contains double quotes — confirm they are stripped correctly