### PR TITLE
[FIX] cr_electronic_invoice: remove duplicate company ID fields on company form

### DIFF
--- a/cr_electronic_invoice/__manifest__.py
+++ b/cr_electronic_invoice/__manifest__.py
@@ -18,6 +18,7 @@
         'sale_management',
         'sales_team',
         'account',
+        'l10n_cr',
         'l10n_cr_country_codes',
         'res_currency_cr_adapter',
         ],

--- a/cr_electronic_invoice/data/ir_cron_data.xml
+++ b/cr_electronic_invoice/data/ir_cron_data.xml
@@ -7,8 +7,6 @@
         <field name="code">model._check_hacienda_for_mrs()</field>
         <field name="interval_number">5</field>
         <field name="interval_type">minutes</field>
-        <field name="numbercall">-1</field>
-        <field name="doall" eval="False" />
     </record>
 
     <record id="ir_cron_FECR_Envia" model="ir.cron">
@@ -18,8 +16,6 @@
         <field name="code">model._send_invoices_to_hacienda()</field>
         <field name="interval_number">10</field>
         <field name="interval_type">minutes</field>
-        <field name="numbercall">-1</field>
-        <field name="doall" eval="False" />
     </record>
 
     <record id="ir_cron_FECR_Consulta" model="ir.cron">
@@ -29,8 +25,6 @@
         <field name="code">model._check_hacienda_for_invoices()</field>
         <field name="interval_number">5</field>
         <field name="interval_type">minutes</field>
-        <field name="numbercall">-1</field>
-        <field name="doall" eval="False" />
     </record>
 
     <record id="ir_cron_mr_hacienda_invoice" model="ir.cron">
@@ -40,8 +34,6 @@
         <field name="code">model.send_mrs_to_hacienda()</field>
         <field name="interval_number">10</field>
         <field name="interval_type">minutes</field>
-        <field name="numbercall">-1</field>
-        <field name="doall" eval="False" />
     </record>
 
     <record id="ir_cron_send_expiration_notice" model="ir.cron">
@@ -51,9 +43,7 @@
         <field name="code">model._cron_send_email_notifications()</field>
         <field name="interval_number">1</field>
         <field name="interval_type">days</field>
-        <field name="numbercall">-1</field>
         <field name="nextcall" eval="(datetime.today() + timedelta(days=1)).strftime('%Y-%m-%d 00:01:00')"></field>
-        <field name="doall" eval="False"/>
     </record>
 
     <record id="ir_cron_vat_exoneration_expired" model="ir.cron">
@@ -63,7 +53,5 @@
         <field name="code">model.check_exonerations()</field>
         <field name="interval_number">1</field>
         <field name="interval_type">days</field>
-        <field name="numbercall">-1</field>
-        <field name="doall" eval="False" />
     </record>
 </odoo>

--- a/cr_electronic_invoice/data/uom_data.xml
+++ b/cr_electronic_invoice/data/uom_data.xml
@@ -1,257 +1,179 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <!-- Resource: uom.category -->
-    <record id="product_uom_categ_area" model="uom.category">
-        <field name="name">Area</field>
-    </record>
-
-    <record id="product_uom_categ_service" model="uom.category">
-        <field name="name">Services</field>
-    </record>
-
-    <record id="product_uom_categ_rent" model="uom.category">
-        <field name="name">Rent</field>
-    </record>
-
-    <!-- Resource: uom.uom -->
+    <!-- Update existing standard UOMs: only name (Spanish) and code for CR electronic invoicing -->
     <record id="uom.product_uom_cm" model="uom.uom">
-        <field name="category_id" ref="uom.uom_categ_length"/>
         <field name="name">Centímetro</field>
         <field name="code">cm</field>
-        <field name="uom_type">smaller</field>
-        <field name="active">True</field>
     </record>
 
     <record id="uom.product_uom_day" model="uom.uom">
-        <field name="category_id" ref="uom.uom_categ_wtime"/>
         <field name="name">Día(s)</field>
         <field name="code">d</field>
-        <field name="active">True</field>
-        <field name="uom_type">reference</field>
     </record>
 
     <record id="uom.product_uom_gram" model="uom.uom">
-        <field name="category_id" ref="uom.product_uom_categ_kgm"/>
         <field name="name">Gramo</field>
         <field name="code">g</field>
-        <field name="uom_type">smaller</field>
-        <field name="active">True</field>
     </record>
 
     <record id="uom.product_uom_gal" model="uom.uom">
-        <field name="category_id" ref="uom.product_uom_categ_vol"/>
         <field name="name">Galón</field>
         <field name="code">Gal</field>
-        <field name="uom_type">bigger</field>
-        <field name="active">True</field>
     </record>
 
     <record id="uom.product_uom_hour" model="uom.uom">
-        <field name="category_id" ref="uom.uom_categ_wtime"/>
         <field name="name">Hora(s)</field>
         <field name="code">h</field>
-        <field name="uom_type">smaller</field>
-        <field name="active">True</field>
     </record>
 
     <record id="uom.product_uom_kgm" model="uom.uom">
-        <field name="category_id" ref="uom.product_uom_categ_kgm"/>
         <field name="name">Kilogramo</field>
         <field name="code">kg</field>
-        <field name="uom_type">reference</field>
-        <field name="active">True</field>
     </record>
 
     <record id="uom.product_uom_km" model="uom.uom">
-        <field name="category_id" ref="uom.uom_categ_length"/>
         <field name="name">Kilómetro</field>
         <field name="code">km</field>
-        <field name="uom_type">bigger</field>
-        <field name="active">True</field>
     </record>
 
     <record id="uom.product_uom_litre" model="uom.uom">
-        <field name="category_id" ref="uom.product_uom_categ_vol"/>
         <field name="name">Litro</field>
         <field name="code">L</field>
-        <field name="uom_type">reference</field>
-        <field name="active">True</field>
     </record>
 
     <record id="uom.product_uom_inch" model="uom.uom">
-        <field name="category_id" ref="uom.uom_categ_length"/>
         <field name="name">Pulgada</field>
         <field name="code">ln</field>
-        <field name="uom_type">smaller</field>
-        <field name="active">True</field>
     </record>
 
     <record id="uom.product_uom_meter" model="uom.uom">
-        <field name="category_id" ref="uom.uom_categ_length"/>
         <field name="name">Metro</field>
         <field name="code">m</field>
-        <field name="uom_type">reference</field>
-        <field name="active">True</field>
     </record>
 
     <record id="uom.product_uom_oz" model="uom.uom">
-        <field name="category_id" ref="uom.product_uom_categ_kgm"/>
         <field name="name">Onzas</field>
         <field name="code">Oz</field>
-        <field name="uom_type">smaller</field>
-        <field name="active">True</field>
     </record>
 
     <record id="uom.product_uom_ton" model="uom.uom">
-        <field name="category_id" ref="uom.product_uom_categ_kgm"/>
         <field name="name">Tonelada</field>
         <field name="code">t</field>
-        <field name="uom_type">bigger</field>
-        <field name="active">True</field>
     </record>
 
     <record id="uom.product_uom_unit" model="uom.uom">
-        <field name="category_id" ref="uom.product_uom_categ_unit"/>
         <field name="name">Unidad</field>
         <field name="code">Unid</field>
-        <field name="uom_type">reference</field>
-        <field name="active">True</field>
-    </record>
-
-    <record id="product_uom_mcubico" model="uom.uom">
-        <field name="category_id" ref="uom.product_uom_categ_vol"/>
-        <field name="name">Metro Cubico</field>
-        <field name="factor" eval="1.0"/>
-        <field name="rounding" eval="0.01"/>
-        <field name="code">m3</field>
-        <field name="uom_type">bigger</field>
-    </record>
-    <record id="product_uom_sp" model="uom.uom">
-        <field name="category_id" ref="product_uom_categ_service"/>
-        <field name="name">Servicios Profesionales</field>
-        <field name="factor" eval="1.0"/>
-        <field name="rounding" eval="0.01"/>
-        <field name="code">Sp</field>
-        <field name="uom_type">reference</field>
-    </record>
-
-    <record id="product_uom_spe" model="uom.uom">
-        <field name="category_id" ref="product_uom_categ_service"/>
-        <field name="name">Servicios Personales</field>
-        <field name="factor" eval="1.0"/>
-        <field name="rounding" eval="0.01"/>
-        <field name="code">Spe</field>
-        <field name="uom_type">smaller</field>
-    </record>
-
-        <record id="product_uom_st" model="uom.uom">
-        <field name="category_id" ref="product_uom_categ_service"/>
-        <field name="name">Servicios Técnicos</field>
-        <field name="factor" eval="1.0"/>
-        <field name="rounding" eval="0.01"/>
-        <field name="code">St</field>
-        <field name="uom_type">smaller</field>
-    </record>
-
-        <record id="product_uom_os" model="uom.uom">
-        <field name="category_id" ref="product_uom_categ_service"/>
-        <field name="name">Otro Tipo de Servicio</field>
-        <field name="factor" eval="1.0"/>
-        <field name="rounding" eval="0.01"/>
-        <field name="code">Os</field>
-        <field name="uom_type">smaller</field>
-    </record>
-
-    <record id="product_uom_i" model="uom.uom">
-        <field name="category_id" ref="uom.product_uom_categ_unit"/>
-        <field name="name">Intereses</field>
-        <field name="code">I</field>
-        <field name="uom_type">bigger</field>
-    </record>
-
-    <record id="product_uom_com" model="uom.uom">
-        <field name="category_id" ref="uom.product_uom_categ_unit"/>
-        <field name="name">Comisiones</field>
-        <field name="factor" eval="1.0"/>
-        <field name="rounding" eval="0.01"/>
-        <field name="code">Cm</field>
-        <field name="uom_type">smaller</field>
-    </record>
-
-    <record id="product_uom_alc" model="uom.uom">
-        <field name="category_id" ref="product_uom_categ_rent"/>
-        <field name="name">Alquiler de Uso Comercial</field>
-        <field name="factor" eval="1.0"/>
-        <field name="rounding" eval="0.01"/>
-        <field name="code">Alc</field>
-        <field name="uom_type">reference</field>
-    </record>
-
-    <record id="product_uom_al" model="uom.uom">
-        <field name="category_id" ref="product_uom_categ_rent"/>
-        <field name="name">Alquiler de Uso Habitacional</field>
-        <field name="factor" eval="1.0"/>
-        <field name="rounding" eval="0.01"/>
-        <field name="code">Al</field>
-        <field name="uom_type">smaller</field>
     </record>
 
     <record id="uom.product_uom_qt" model="uom.uom">
-        <field name="category_id" ref="uom.product_uom_categ_vol"/>
         <field name="name">Cuarto(s) de Galón</field>
         <field name="code">cuarto(s) de galón</field>
-        <field name="uom_type">smaller</field>
-        <field name="active">False</field>
+        <field name="active" eval="False"/>
     </record>
 
     <record id="uom.product_uom_dozen" model="uom.uom">
-        <field name="category_id" ref="uom.product_uom_categ_unit"/>
         <field name="name">Docena(s)</field>
         <field name="code">Docena(s)</field>
-        <field name="uom_type">bigger</field>
-        <field name="active">False</field>
+        <field name="active" eval="False"/>
     </record>
 
     <record id="uom.product_uom_floz" model="uom.uom">
-        <field name="category_id" ref="uom.product_uom_categ_vol"/>
         <field name="name">fl oz</field>
         <field name="code">fl oz</field>
-        <field name="uom_type">smaller</field>
-        <field name="active">False</field>
+        <field name="active" eval="False"/>
     </record>
 
     <record id="uom.product_uom_lb" model="uom.uom">
-        <field name="category_id" ref="uom.product_uom_categ_kgm"/>
         <field name="name">Libra(s)</field>
         <field name="code">libra(s)</field>
-        <field name="uom_type">smaller</field>
-        <field name="active">False</field>
+        <field name="active" eval="False"/>
     </record>
 
     <record id="uom.product_uom_mile" model="uom.uom">
-        <field name="category_id" ref="uom.uom_categ_length"/>
         <field name="name">Milla(s)</field>
         <field name="code">milla(s)</field>
-        <field name="uom_type">bigger</field>
-        <field name="active">False</field>
+        <field name="active" eval="False"/>
     </record>
 
     <record id="uom.product_uom_foot" model="uom.uom">
-        <field name="category_id" ref="uom.uom_categ_length"/>
         <field name="name">Pie(s)</field>
         <field name="code">pie(s)</field>
-        <field name="uom_type">smaller</field>
-        <field name="active">False</field>
+        <field name="active" eval="False"/>
     </record>
 
+    <!-- Custom CR UOMs: Services (root UOM, relative_factor=1.0, no parent) -->
+    <record id="product_uom_sp" model="uom.uom">
+        <field name="name">Servicios Profesionales</field>
+        <field name="code">Sp</field>
+        <field name="relative_factor" eval="1.0"/>
+    </record>
+
+    <record id="product_uom_spe" model="uom.uom">
+        <field name="name">Servicios Personales</field>
+        <field name="code">Spe</field>
+        <field name="relative_factor" eval="1.0"/>
+        <field name="relative_uom_id" ref="product_uom_sp"/>
+    </record>
+
+    <record id="product_uom_st" model="uom.uom">
+        <field name="name">Servicios Técnicos</field>
+        <field name="code">St</field>
+        <field name="relative_factor" eval="1.0"/>
+        <field name="relative_uom_id" ref="product_uom_sp"/>
+    </record>
+
+    <record id="product_uom_os" model="uom.uom">
+        <field name="name">Otro Tipo de Servicio</field>
+        <field name="code">Os</field>
+        <field name="relative_factor" eval="1.0"/>
+        <field name="relative_uom_id" ref="product_uom_sp"/>
+    </record>
+
+    <!-- Custom CR UOMs: Financial units -->
+    <record id="product_uom_i" model="uom.uom">
+        <field name="name">Intereses</field>
+        <field name="code">I</field>
+        <field name="relative_factor" eval="1.0"/>
+        <field name="relative_uom_id" ref="uom.product_uom_unit"/>
+    </record>
+
+    <record id="product_uom_com" model="uom.uom">
+        <field name="name">Comisiones</field>
+        <field name="code">Cm</field>
+        <field name="relative_factor" eval="1.0"/>
+        <field name="relative_uom_id" ref="uom.product_uom_unit"/>
+    </record>
+
+    <!-- Custom CR UOMs: Rental -->
+    <record id="product_uom_alc" model="uom.uom">
+        <field name="name">Alquiler de Uso Comercial</field>
+        <field name="code">Alc</field>
+        <field name="relative_factor" eval="1.0"/>
+    </record>
+
+    <record id="product_uom_al" model="uom.uom">
+        <field name="name">Alquiler de Uso Habitacional</field>
+        <field name="code">Al</field>
+        <field name="relative_factor" eval="1.0"/>
+        <field name="relative_uom_id" ref="product_uom_alc"/>
+    </record>
+
+    <!-- Custom CR UOMs: Volume -->
+    <record id="product_uom_mcubico" model="uom.uom">
+        <field name="name">Metro Cubico</field>
+        <field name="code">m3</field>
+        <field name="relative_factor" eval="1000.0"/>
+        <field name="relative_uom_id" ref="uom.product_uom_litre"/>
+    </record>
+
+    <!-- Custom CR UOMs: Area -->
     <record id="product_uom_mcuadrado" model="uom.uom">
-        <field name="category_id" ref="product_uom_categ_area"/>
         <field name="name">Metro Cuadrado</field>
-        <field name="factor" eval="1.0"/>
-        <field name="rounding" eval="0.01"/>
         <field name="code">m2</field>
-        <field name="uom_type">reference</field>
-    </record> 
+        <field name="relative_factor" eval="1.0"/>
+        <field name="relative_uom_id" ref="uom.product_uom_square_meter"/>
+    </record>
 
 </odoo>

--- a/cr_electronic_invoice/models/account_move.py
+++ b/cr_electronic_invoice/models/account_move.py
@@ -326,7 +326,7 @@ class AccountInvoiceElectronic(models.Model):
 
         self.set_currency_rate()
 
-        email_template = self.invoice_id.move_type in ['in_invoice', 'in_refund'] and \
+        email_template = self.move_type in ['in_invoice', 'in_refund'] and \
             self.env.ref('cr_electronic_invoice.email_template_invoice_vendor', raise_if_not_found=False) or \
             self.env.ref('account.email_template_edi_invoice',
                          raise_if_not_found=False)
@@ -381,18 +381,11 @@ class AccountInvoiceElectronic(models.Model):
             raise UserError(_('Partner is not assigne to this invoice'))
 
         compose_form = self.env.ref(
-            'account.account_invoice_send_wizard_form', raise_if_not_found=False).sudo()
+            'account.account_move_send_wizard_form', raise_if_not_found=False)
         ctx = dict(
-            default_model='account.move',
-            default_res_id=self.id,
-            default_res_model='account.move',
-            default_use_template=bool(email_template),
+            active_model='account.move',
+            active_ids=[self.id],
             default_template_id=email_template and email_template.id or False,
-            default_composition_mode='comment',
-            mark_invoice_as_sent=True,
-            custom_layout="mail.mail_notification_paynow",
-            model_description=self.with_context(lang=lang).type_name,
-            force_email=True
         )
 
         return {
@@ -400,9 +393,9 @@ class AccountInvoiceElectronic(models.Model):
             'type': 'ir.actions.act_window',
             'view_type': 'form',
             'view_mode': 'form',
-            'res_model': 'account.invoice.send',
-            'views': [(compose_form.id, 'form')],
-            'view_id': compose_form.id,
+            'res_model': 'account.move.send.wizard',
+            'views': [(compose_form.id if compose_form else False, 'form')],
+            'view_id': compose_form.id if compose_form else False,
             'target': 'new',
             'context': ctx,
         }
@@ -1504,9 +1497,8 @@ class AccountInvoiceElectronic(models.Model):
                         continue
 
             # Calcular si aplica IVA Devuelto
-            # Sólo aplica para clínicas y para pago por tarjeta
-            actividad_iva_devuelto = 'CLINICA, CENTROS MEDICOS, HOSPITALES PRIVADOS Y OTROS'
-            if inv.economic_activity_id.name == actividad_iva_devuelto and inv.payment_methods_id.sequence == '02':
+            # Aplica cuando el pago es con tarjeta y el producto tiene el flag iva_devuelto_tarjeta
+            if inv.payment_methods_id.sequence == '02':
                 prod_iva_devuelto = self.env.ref('cr_electronic_invoice.product_iva_devuelto')
                 iva_devuelto = 0
                 for inv_line in inv.invoice_line_ids:
@@ -1514,7 +1506,7 @@ class AccountInvoiceElectronic(models.Model):
                         # Remove any existing IVA Devuelto lines
                         if inv_line.product_id.id == prod_iva_devuelto.id:
                             inv_line.unlink()
-                        elif inv_line.product_id.categ_id.name == 'Servicios de Salud':
+                        elif inv_line.product_id.iva_devuelto_tarjeta:
                             iva_devuelto += inv_line.price_tax
                 if iva_devuelto:
                     self.env['account.move.line'].create({

--- a/cr_electronic_invoice/models/product_template.py
+++ b/cr_electronic_invoice/models/product_template.py
@@ -28,6 +28,11 @@ class ProductElectronic(models.Model):
     non_tax_deductible = fields.Boolean(string='Is Non Tax Deductible',
                                         help='Indicates if this product is non-tax deductible')
 
+    iva_devuelto_tarjeta = fields.Boolean(
+        string='IVA Devuelto con Tarjeta',
+        help='Si está activo, el IVA de este producto/servicio se devuelve automáticamente cuando el pago es con tarjeta.'
+    )
+
 
 class ProductCategory(models.Model):
     _inherit = "product.category"

--- a/cr_electronic_invoice/models/res_company.py
+++ b/cr_electronic_invoice/models/res_company.py
@@ -98,6 +98,11 @@ class CompanyElectronic(models.Model):
     url_base_exo = fields.Char(string="URL Base EXONET", help="URL Base ENDPOINT EXONET",
                                default="https://api.hacienda.go.cr/fe/ex?")
 
+    @api.onchange('vat')
+    def _onchange_vat_sync_registry(self):
+        if self.vat:
+            self.company_registry = self.vat
+
     @api.constrains('invoice_qr_type', 'invoice_field_ids')
     def check_invoice_field_ids(self):
         if self.invoice_qr_type == 'by_info' and not self.invoice_field_ids:

--- a/cr_electronic_invoice/views/account_move_views.xml
+++ b/cr_electronic_invoice/views/account_move_views.xml
@@ -137,11 +137,10 @@
                 <attribute name="decoration-danger">
                     state_tributacion == 'rechazado'
                 </attribute>
-            </tree>
-            <field name="state" position="before">
+            </list>
+            <field name="move_type" position="before">
                 <field name="tipo_documento" string="Doc Elect." optional="show"/>
                 <field name="sequence" string="Consecutive" optional="show"/>
-                <field name="move_type" column_invisible="1" readonly="1"/>
                 <field name="state_tributacion" string="State FE" optional="show"/>
             </field>
         </field>

--- a/cr_electronic_invoice/views/account_portal_templates.xml
+++ b/cr_electronic_invoice/views/account_portal_templates.xml
@@ -1,82 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <template id="account.portal_my_invoices" name="My Invoices and Payments">
-        <t t-call="portal.portal_layout">
-            <t t-set="breadcrumbs_searchbar" t-value="True"/>
-
-            <t t-call="portal.portal_searchbar">
-                <t t-set="title">Invoices</t>
-            </t>
-            <t t-if="not invoices">
-                <p>There are currently no invoices and payments for your account.</p>
-            </t>
-            <t t-if="invoices" t-call="portal.portal_table">
-                <thead>
-                    <tr class="active">
-                        <th>Invoice #</th>
-                        <th>Invoice Date</th>
-                        <th class='d-none d-md-table-cell'>Due Date</th>
-                        <th/>
-                        <th class="text-right">Doc. Elect.</th>
-                        <th class="text-right">Estado Tributación</th>
-                        <th class="text-right">Amount Due</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <t t-foreach="invoices" t-as="invoice">
-                        <tr>
-                            <td>
-                                <a t-att-href="invoice.get_portal_url()" t-att-title="invoice.name">
-                                    <t t-esc="invoice.name" t-if="invoice.name != '/'"/>
-                                    <em t-else="">Draft Invoice</em>
-                                </a>
-                            </td>
-                            <td>
-                                <span t-field="invoice.invoice_date"/>
-                            </td>
-                            <td class='d-none d-md-table-cell'>
-                                <span t-field="invoice.invoice_date_due"/>
-                            </td>
-                            <td class="tx_status">
-                                <t t-if="invoice.state == 'posted' and invoice.payment_state not in ('in_payment', 'paid', 'reversed')">
-                                    <span class="badge badge-pill badge-info">
-                                        <i class="fa fa-fw fa-clock-o" aria-label="Opened" title="Opened" role="img"></i>
-                                        <span class="d-none d-md-inline"> Waiting for Payment</span>
-                                    </span>
-                                </t>
-                                <t t-if="invoice.state == 'posted' and invoice.payment_state in ('paid', 'in_payment')">
-                                    <span class="badge badge-pill badge-success">
-                                        <i class="fa fa-fw fa-check" aria-label="Paid" title="Paid" role="img"></i>
-                                        <span class="d-none d-md-inline"> Paid</span>
-                                    </span>
-                                </t>
-                                <t t-if="invoice.state == 'posted' and invoice.payment_state == 'reversed'">
-                                    <span class="badge badge-pill badge-success">
-                                        <i class="fa fa-fw fa-check" aria-label="Reversed" title="Reversed" role="img"></i>
-                                        <span class="d-none d-md-inline"> Reversed</span>
-                                    </span>
-                                </t>
-                                <t t-if="invoice.state == 'cancel'">
-                                    <span class="badge badge-pill badge-warning">
-                                        <i class="fa fa-fw fa-remove" aria-label="Cancelled" title="Cancelled" role="img"></i>
-                                        <span class="d-none d-md-inline"> Cancelled</span>
-                                    </span>
-                                </t>
-                            </td>
-                            <td class="text-right">
-                                <span t-field="invoice.tipo_documento"/>
-                            </td>
-                            <td class="text-right">
-                                <span t-field="invoice.state_tributacion"/>
-                            </td>
-                            <td class="text-right">
-                                <span t-esc="-invoice.amount_residual if invoice.move_type == 'out_refund' else invoice.amount_residual" t-options='{"widget": "monetary", "display_currency": invoice.currency_id}'/>
-                            </td>
-                        </tr>
-                    </t>
-                </tbody>
-            </t>
-        </t>
+    <template id="portal_my_invoices_cr" name="CR Electronic Invoice Columns" inherit_id="account.portal_my_invoices">
+        <xpath expr="//th[@name='amount_due']" position="before">
+            <th class="text-end">Doc. Elect.</th>
+            <th class="text-end">Estado Tributación</th>
+        </xpath>
+        <xpath expr="//td[@name='invoice_amount']" position="before">
+            <td class="text-end">
+                <span t-field="invoice.tipo_documento"/>
+            </td>
+            <td class="text-end">
+                <span t-field="invoice.state_tributacion"/>
+            </td>
+        </xpath>
     </template>
 
     <template id="account.portal_invoice_page" name="Invoice Portal Template" inherit_id="portal.portal_sidebar" primary="True">

--- a/cr_electronic_invoice/views/product_views.xml
+++ b/cr_electronic_invoice/views/product_views.xml
@@ -6,9 +6,10 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_form_view"/>
         <field name="arch" type="xml">
-            <field name="detailed_type" position="after">
+            <field name="type" position="after">
                 <field name="economic_activity_id" domain="[('active', '=', True)]" options='{"no_open": True, "no_create": True}'/>
                 <field name="non_tax_deductible" default="0"/>
+                <field name="iva_devuelto_tarjeta"/>
                 <field name="code_type_id" required="0"/>
                 <field name="commercial_measurement" required="0"/>
                 <field name="cabys_code" />

--- a/cr_electronic_invoice/views/report_invoice_document.xml
+++ b/cr_electronic_invoice/views/report_invoice_document.xml
@@ -223,6 +223,9 @@
                     </div>
                     <p t-if="o.move_type in ('out_invoice', 'in_refund') and o.payment_reference" name="payment_communication">
                         Please use the following communication for your payment : <b><span t-field="o.payment_reference"/></b>
+                        <t t-if="o.partner_bank_id">
+                            <br/> on this account: <span t-field="o.partner_bank_id" class="fw-bold"/>
+                        </t>
                     </p>
                     <p t-if="o.invoice_payment_term_id" name="payment_term">
                         <span t-field="o.invoice_payment_term_id.note"/>

--- a/cr_electronic_invoice/views/res_company_views.xml
+++ b/cr_electronic_invoice/views/res_company_views.xml
@@ -26,9 +26,15 @@
                 <button name="action_get_economic_activities" type="object" string="Consultar Actividad Economica en Hacienda" colspan="2" />
             </field>
 
-            <field name="partner_id" position="after">
+            <field name="vat" position="before">
                 <field name="identification_id"/>
-                <field name="vat"/>
+            </field>
+
+            <field name="company_registry" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+            <field name="company_registry_placeholder" position="attributes">
+                <attribute name="invisible">1</attribute>
             </field>
 
             <!-- <field name="incoterm_id" position="attributes">

--- a/cr_electronic_invoice/views/res_config_settings_views.xml
+++ b/cr_electronic_invoice/views/res_config_settings_views.xml
@@ -1,74 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <record id="res_config_settings_view_form" model="ir.ui.view">
-        <field name="name">res.config.settings.view.form</field>
-        <field name="model">res.config.settings</field>
-        <field name="inherit_id" ref="account.res_config_settings_view_form"/>
-        <field name="arch" type="xml">
-            <xpath expr="//app[@name='account']" position="inside">
-                <h2>Product Catalog</h2>
-                <div class="row mt16 o_settings_container">
-                    <div class="col-xs-12 col-md-6 o_setting_box">
-                        <div class="o_setting_left_pane">
-                            <field name="group_product_variant"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="group_product_variant"/>
-                            <div class="text-muted">
-                                    Set product attributes (e.g. color, size) to sell variants
-                            </div>
-                            <div class="content-group" invisible="not group_product_variant">
-                                <div class="mt16">
-                                    <button name="%(product.attribute_action)d" icon="fa-arrow-right" type="action" string="Attributes" class="btn-link"/>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-xs-12 col-md-6 o_setting_box">
-                        <div class="o_setting_left_pane">
-                            <field name="group_uom"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="group_uom"/>
-                            <div class="text-muted">
-                                    Sell and purchase products in different units of measure
-                            </div>
-                            <div class="content-group" invisible="not group_uom">
-                                <div class="mt16">
-                                    <button name="%(uom.product_uom_form_action)d" icon="fa-arrow-right" type="action" string="Units of Measure" class="btn-link"/>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-xs-12 col-md-6 o_setting_box" title="Sending an email is useful if you need to share specific information or content about a product (instructions, rules, links, media, etc.). Create and set the email template from the product detail form (in Sales tab).">
-                        <div class="o_setting_left_pane">
-                            <field name="module_product_email_template"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="module_product_email_template"/>
-                            <div class="text-muted">
-                                    Send a product-specific email once the invoice is paid
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-xs-12 col-md-6 o_setting_box" title="Ability to select a package type in sales orders and to force a quantity that is a multiple of the number of units per package.">
-                        <div class="o_setting_left_pane">
-                            <field name="group_stock_packaging"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="group_stock_packaging"/>
-                            <div class="text-muted">
-                                    Sell products by multiple of unit # per package
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </xpath>
-
-        </field>
-    </record>
-
     <record id="res_config_settings_view_form_inherit" model="ir.ui.view">
         <field name="name">res.config.settings.view.form.inherit</field>
         <field name="model">res.config.settings</field>
@@ -81,7 +13,7 @@
                             <div class="o_form_label">Default product used for expenses when importing electronic invoice</div>
                             <field name="expense_product_id" string="Default product for expenses when importing electronic invoice" />
                             <div class="o_form_label">Default account used for expenses when importing electronic invoice</div>
-                            <field name="expense_account_id" string="Default account for expenses when importing electronic invoice" required="1" />
+                            <field name="expense_account_id" string="Default account for expenses when importing electronic invoice"  />
                             <div class="o_form_label">Default analytic account used for expenses when importing electronic invoice</div>
                             <field name="expense_analytic_account_id" string="Default analytic account for expenses when importing electronic invoice"/>
                             <div class="o_form_label">Load invoice lines?</div>

--- a/cr_electronic_invoice/views/res_partner_views.xml
+++ b/cr_electronic_invoice/views/res_partner_views.xml
@@ -23,7 +23,7 @@
                     <separator colspan="7"/>
                     <field name="activity_id" domain="[('id', 'in', economic_activities_ids)]" options="{&quot;no_create&quot;: True, &quot;active_test&quot;: False}" colspan="5" />
                     <button name="action_get_economic_activities" type="object" string="Consultar Actividad Economica en Hacienda" colspan="2" />
-                    <field name="economic_activities_ids" readonly="0" widget="section_and_note_one2many" mode="tree" context="{'partner_id': id}" colspan="7">
+                    <field name="economic_activities_ids" readonly="0" widget="section_and_note_one2many" mode="list" context="{'partner_id': id}" colspan="7">
                         <list editable="bottom">
                             <field name="code" />
                             <field name="name"/>

--- a/cr_electronic_invoice/wizard/account_invoice_send.py
+++ b/cr_electronic_invoice/wizard/account_invoice_send.py
@@ -1,28 +1,13 @@
 from odoo import models
-from odoo.tools.misc import get_lang
 
 
 class AccountInvoiceSend(models.TransientModel):
-    _inherit = 'account.invoice.send'
+    _inherit = 'account.move.send.wizard'
 
-    def send_and_print_action(self):
+    def action_send_and_print(self, allow_fallback_pdf=False):
         self.ensure_one()
-        if self.composition_mode == 'mass_mail' and self.template_id:
-            for move in self.invoice_ids:
-                if move.company_id.frm_ws_ambiente == 'disabled':
-                    active_records = self.env[self.model].browse(move.ids)
-                    langs = active_records.mapped('partner_id.lang')
-                    default_lang = get_lang(self.env)
-                    for lang in (set(langs) or [default_lang]):
-                        active_ids_lang = active_records.filtered(lambda r: r.partner_id.lang == lang).ids
-                        self_lang = self.with_context(active_ids=active_ids_lang, lang=lang)
-                        self_lang.onchange_template_id()
-                        self_lang._send_email()
-                else:
-                    if move.state_tributacion == 'aceptado':
-                        move.action_invoice_sent_mass()
-        else:
-            self._send_email()
-        if self.is_print:
-            return self._print_document()
-        return {'type': 'ir.actions.act_window_close'}
+        move = self.move_id
+        if move.company_id.frm_ws_ambiente != 'disabled' and move.state_tributacion == 'aceptado':
+            move.action_invoice_sent_mass()
+            return {'type': 'ir.actions.act_window_close'}
+        return super().action_send_and_print(allow_fallback_pdf=allow_fallback_pdf)

--- a/cr_electronic_invoice_pos/data/data.xml
+++ b/cr_electronic_invoice_pos/data/data.xml
@@ -9,8 +9,6 @@
         <field name="code">model._consultahacienda_pos(20)</field>
         <field name="interval_number">5</field>
         <field name="interval_type">minutes</field>
-        <field name="numbercall">-1</field>
-        <field name="doall" eval="False"/>
     </record>
 
     <record id="ir_cron_valida_hacienda_pos" model="ir.cron">
@@ -20,8 +18,6 @@
         <field name="code">model._validahacienda_pos(20)</field>
         <field name="interval_number">5</field>
         <field name="interval_type">minutes</field>
-        <field name="numbercall">-1</field>
-        <field name="doall" eval="False"/>
     </record>
 
     <record id="ir_cron_reenvia_correos_pos" model="ir.cron">
@@ -31,8 +27,6 @@
         <field name="code">model._reenviacorreos_pos()</field>
         <field name="interval_number">5</field>
         <field name="interval_type">minutes</field>
-        <field name="numbercall">-1</field>
-        <field name="doall" eval="False"/>
     </record>
 
 </odoo>

--- a/l10n_cr_country_codes/views/res_company_views.xml
+++ b/l10n_cr_country_codes/views/res_company_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="base.view_company_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='city']" position="attributes">
-                <attribute name="attrs">{'invisible': [('country_id','=',%(base.cr)d)]}</attribute>
+                <attribute name="invisible">country_id == %(base.cr)d</attribute>
             </xpath>
 
             <xpath expr="//field[@name='zip']" position="replace">

--- a/res_currency_cr_adapter/models/res_currency.py
+++ b/res_currency_cr_adapter/models/res_currency.py
@@ -3,7 +3,7 @@
 
 from odoo import api, fields, models
 from zeep import Client
-from datetime import timedelta, datetime
+from datetime import timedelta, datetime, date as date_type
 import xml.etree.ElementTree
 import logging
 import requests
@@ -77,6 +77,15 @@ class ResCurrencyRate(models.Model):
 
         _logger.info("=========================================================")
         _logger.info("Executing exchange rate update from 1 CRC = X USD")
+
+        if isinstance(first_date, str):
+            first_date = datetime.strptime(first_date, '%Y-%m-%d').date()
+        elif isinstance(first_date, datetime):
+            first_date = first_date.date()
+        if isinstance(last_date, str):
+            last_date = datetime.strptime(last_date, '%Y-%m-%d').date()
+        elif isinstance(last_date, datetime):
+            last_date = last_date.date()
 
         exchange_source = self.env['ir.config_parameter'].sudo().get_param('exchange_source')
         if exchange_source == 'bccr':
@@ -172,40 +181,66 @@ class ResCurrencyRate(models.Model):
 
             # Get current date to get exchange rate for today
             if first_date:
-                initial_date = first_date.strftime('%Y-%m-%d')
-                end_date = last_date.strftime('%Y-%m-%d')
+                currency_rate_obj = self.env['res.currency.rate']
+                currency_usd = self.env['res.currency'].search([('name', '=', 'USD')], limit=1)
+                companies = self.env['res.company'].search([])
 
-                try:
-                    url = 'https://api.hacienda.go.cr/indicadores/tc/dolar/historico/?d='+initial_date+'&h='+end_date
-                    response = requests.get(url, timeout=5, verify=False)
-
-                except requests.exceptions.RequestException as e:
-                    _logger.error('RequestException %s', e)
+                # Hacienda API returns ~60 days max per request; chunk into 60-day batches
+                chunk_size = timedelta(days=60)
+                all_data = []
+                if not isinstance(first_date, date_type) or not isinstance(last_date, date_type):
                     return False
-                if response.status_code in (200,):
-                    data = response.json()
-                    companies = self.env['res.company'].search([])
-                    for company in companies:
-                        _logger.error(company.id)
+                chunk_start = first_date
+                end = last_date
 
-                        for rate_line in data:
-                            today = datetime.strptime(rate_line['fecha'], '%Y-%m-%d %H:%M:%S')
-                            vals = {}
-                            vals['original_rate'] = rate_line['venta']
-                            # Odoo utiliza un valor inverso,
-                            # a cuantos dólares equivale 1 colón, por eso se divide 1 / tipo de cambio.
-                            vals['rate'] = 1 / vals['original_rate']
-                            vals['original_rate_2'] = rate_line['compra']
-                            vals['rate_2'] = 1 / vals['original_rate_2']
-                            vals['currency_id'] = self.env.ref('base.USD').id
+                while chunk_start <= end:
+                    chunk_end = min(chunk_start + chunk_size - timedelta(days=1), end)
+                    try:
+                        url = ('https://api.hacienda.go.cr/indicadores/tc/dolar/historico/?d='
+                               + chunk_start.strftime('%Y-%m-%d') + '&h=' + chunk_end.strftime('%Y-%m-%d'))
+                        _logger.info('Hacienda request chunk %s → %s', chunk_start, chunk_end)
+                        response = requests.get(url, timeout=10, verify=False)
+                        if response.status_code == 200:
+                            chunk_data = response.json()
+                            _logger.info('Hacienda chunk returned %d records', len(chunk_data))
+                            all_data.extend(chunk_data)
+                        else:
+                            _logger.error('Hacienda API returned %s for chunk %s-%s',
+                                          response.status_code, chunk_start, chunk_end)
+                    except requests.exceptions.RequestException as e:
+                        _logger.error('RequestException %s', e)
+                    chunk_start = chunk_end + timedelta(days=1)
 
-                            rate_id = self.env['res.currency.rate'].search([('name', '=', today.date())], limit=1)
+                _logger.info('Hacienda total records collected: %d', len(all_data))
+
+                for company in companies:
+                    for rate_line in all_data:
+                            fecha_str = rate_line['fecha']
+                            try:
+                                rate_date = datetime.strptime(fecha_str, '%Y-%m-%d %H:%M:%S').date()
+                            except ValueError:
+                                rate_date = datetime.strptime(fecha_str, '%Y-%m-%d').date()
+
+                            vals = {
+                                'original_rate': rate_line['venta'],
+                                'rate': 1 / rate_line['venta'],
+                                'original_rate_2': rate_line['compra'],
+                                'rate_2': 1 / rate_line['compra'],
+                                'currency_id': currency_usd.id,
+                                'company_id': company.id,
+                            }
+
+                            rate_id = currency_rate_obj.search([
+                                ('name', '=', rate_date),
+                                ('currency_id', '=', currency_usd.id),
+                                ('company_id', '=', company.id),
+                            ], limit=1)
 
                             if rate_id:
                                 rate_id.write(vals)
                             else:
-                                vals['name'] = today.date()
-                                self.create(vals)
+                                vals['name'] = rate_date
+                                currency_rate_obj.create(vals)
             else:
                 try:
                     url = 'https://api.hacienda.go.cr/indicadores/tc'

--- a/res_currency_cr_adapter/views/res_config_settings_views.xml
+++ b/res_currency_cr_adapter/views/res_config_settings_views.xml
@@ -6,17 +6,21 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='currency_exchange_journal_id']" position="after">
-                    <div class="o_form_label col-lg-4 o_light_label">Origen del tipo de cambio</div>
-                    <field name="exchange_source" string="Origen del tipo de cambio" class="o_form_label col-lg-4 o_light_label"/>
-                    <div invisible="exchange_source != 'bccr'" class="o_form_label col-lg-4 o_light_label">Username registered in the BCCR</div>
-                    <field invisible="exchange_source != 'bccr'" name="bccr_username" string="User name registered in the BCCR" />
-                    <div invisible="exchange_source != 'bccr'" class="o_form_label col-lg-4 o_light_label">Email registered in the BCCR</div>
-                    <field invisible="exchange_source != 'bccr'" name="bccr_email" string="email registered in the BCCR" />
-                    <div invisible="exchange_source != 'bccr'" class="o_form_label col-lg-4 o_light_label">BCCR Token</div>
-                    <field invisible="exchange_source != 'bccr'" name="bccr_token" string="BCCR Token" password="True" />
+            <xpath expr="//block[@name='main_currency_setting_container']" position="inside">
+                <setting string="Origen del tipo de cambio">
+                    <field name="exchange_source"/>
+                </setting>
+                <setting string="Usuario BCCR" invisible="exchange_source != 'bccr'">
+                    <field name="bccr_username" string="Usuario registrado en el BCCR"/>
+                </setting>
+                <setting string="Email BCCR" invisible="exchange_source != 'bccr'">
+                    <field name="bccr_email" string="Email registrado en el BCCR"/>
+                </setting>
+                <setting string="Token BCCR" invisible="exchange_source != 'bccr'">
+                    <field name="bccr_token" string="Token BCCR" password="True"/>
+                </setting>
             </xpath>
-       </field>
+        </field>
     </record>
 
 </odoo>

--- a/res_currency_cr_adapter/views/res_currency_rate_view.xml
+++ b/res_currency_cr_adapter/views/res_currency_rate_view.xml
@@ -26,18 +26,10 @@
             <!-- <xpath expr="//button[@name='65']" position="before">
                 <button class="oe_stat_button" string="Update" type="object" icon="fa-refresh" name="action_create_missing_exchange_rates" attrs="{'invisible': [('active', '=', False)]}"/>
             </xpath> -->
-            <xpath expr="//sheet" position="inside">
-                <field string="Rates" name="rate_ids" widget="one2many">
-                    <list string="Rates" editable="top" limit="25">
-                        <field name="name"/>
-                        <field name="company_id" groups="base.group_multi_company"/>
-                        <field name="rate" digits="[12,12]" optional="hide"/>
-                        <field name="original_rate" optional="show"/>
-                        <field name="rate_2" digits="[12,12]" optional="hide"/>
-                        <field name="original_rate_2" optional="show"/>
-                        <field name="write_date" optional="show"/>
-                    </list>
-                </field>
+            <xpath expr="//field[@name='rate_ids']//field[@name='write_date']" position="before">
+                <field name="original_rate" optional="show"/>
+                <field name="rate_2" digits="[12,12]" optional="hide"/>
+                <field name="original_rate_2" optional="show"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
## Summary

- Company form was showing the identification number three times: `vat` and `company_registry` from the base Odoo 19 form, plus a duplicate `vat` injected by the CR module after `partner_id`
- Moved `identification_id` xpath to `position="before"` on the base `vat` field so the type selector and number appear together in the correct location
- Removed the duplicate `vat` field that was being re-added
- Hidden `company_registry` and its placeholder from the view (redundant in Costa Rica where the cedula serves both purposes)
- Added `@api.onchange('vat')` to keep `company_registry` in sync for Odoo core compatibility (report headers, etc.)

## Test plan

- [ ] Upgrade module: `-u cr_electronic_invoice`
- [ ] Open Settings > Companies > your company — confirm `identification_id` and `vat` appear once each, `company_registry` is hidden
- [ ] Set a VAT value and save — confirm `company_registry` is synced to the same value