### PR TITLE
[FIX] res_currency_cr_adapter: migrate BCCR rates to the SDDE REST API

### DIFF
--- a/res_currency_cr_adapter/__manifest__.py
+++ b/res_currency_cr_adapter/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Costa Rica Currency Adapter',
-    'version': '16.0.1.0.0',
+    'version': '16.0.2.0.0',
     'category': 'Account',
     'author': "Odoo CR, Akurey S.A.",
     'website': 'https://github.com/akurey/ak-odoo',
@@ -17,7 +17,6 @@
         'views/res_currency_rate_view.xml',
         'views/res_config_settings_views.xml',
     ],
-    'external_dependencies': {'python': ['zeep']},
     'installable': True,
     'auto_install': False,
 }

--- a/res_currency_cr_adapter/models/res_config_settings.py
+++ b/res_currency_cr_adapter/models/res_config_settings.py
@@ -13,9 +13,15 @@ class ResConfigSettings(models.TransientModel):
         ('hacienda', 'Hacienda')
         ], required=True, default='disabled')
 
+    # Kept for backwards compatibility: the retired SOAP service took the user
+    # name as a request parameter, the SDDE REST API does not use it
     bccr_username = fields.Char(string="BCCR username")
     bccr_email = fields.Char(string="e-mail registered in the BCCR")
-    bccr_token = fields.Char(string="Token to use in the BCCR",)
+    bccr_token = fields.Char(
+        string="BCCR access token",
+        help="Bearer token generated on the Indicadores Economicos site "
+             "under Mi Perfil -> Generar token. It is not the subscription "
+             "token of the old SOAP web service.")
 
     @api.model
     def get_values(self):

--- a/res_currency_cr_adapter/models/res_currency.py
+++ b/res_currency_cr_adapter/models/res_currency.py
@@ -2,13 +2,34 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
-from zeep import Client
 from datetime import timedelta, datetime
-import xml.etree.ElementTree
 import logging
 import requests
 
 _logger = logging.getLogger(__name__)
+
+# The old SOAP service (wsindicadoreseconomicos.asmx) was retired and answers
+# 503; the SDDE REST API is mandatory since 2025-04-07. The token is no longer
+# a subscription parameter, it is a bearer token generated from the
+# Indicadores Economicos site under Mi Perfil -> Generar token.
+BCCR_API_BASE = 'https://apim.bccr.fi.cr/SDDE/api/Bccr.GE.SDDE.Publico.Indicadores.API'
+BCCR_SELLING_INDICATOR = '318'  # Tipo cambio venta
+BCCR_BUYING_INDICATOR = '317'  # Tipo cambio compra
+BCCR_TIMEOUT = 60
+
+# The API gateway answers 403 to the default user agent of the requests
+# library, which is why the BCCR sets one explicitly on its own example
+BCCR_USER_AGENT = 'Odoo/16.0 (res_currency_cr_adapter)'
+
+# Causes documented on Anexo C of the SDDE standard
+BCCR_HTTP_ERRORS = {
+    400: "invalid parameters, check the indicator code and that dates use yyyy/mm/dd",
+    401: "the token is missing, invalid or expired",
+    403: "the user has no valid subscription, or the gateway rejected the user agent",
+    404: "wrong endpoint, or the 'idioma' parameter is missing",
+    429: "too many requests, lower the frequency of the cron",
+    500: "BCCR internal error, or the token was rejected",
+}
 
 
 class ResCurrency(models.Model):
@@ -21,34 +42,34 @@ class ResCurrency(models.Model):
             currency.action_create_missing_exchange_rates()
 
     def action_create_missing_exchange_rates(self):
+        # It is validated that the currency is dollars
+        if self.id != self.env.ref('base.USD').id:
+            return
+
         currency_rate_obj = self.env['res.currency.rate']
-        # A day is added to fix the loss of the current day
-        today = datetime.date.today()
-        last_day = today + datetime.timedelta(days=1)
+        today = fields.Date.context_today(self)
 
         first_day = currency_rate_obj.search([
             ('company_id', '=', self.env.user.company_id.id),
             ('currency_id', '=', self.id)
         ], limit=1, order='name asc')
+
         # If there is no record, you must fill the table with the current day
-        if not first_day:
-            # It is validated that the currency is dollars
-            if self.id == self.env.ref('base.USD').id:
-                # This will create the record of the day the option is run manually
-                currency_rate_obj._cron_update()
-        else:
-            range_day = last_day - first_day.name
-            date = first_day.name
-            for day in range(range_day.days):
-                if self.id == self.env.ref('base.USD').id:
-                    # It is validated if the exchange rate of that day really not exists
-                    if not currency_rate_obj.search([('name', '=', date)], limit=1):
-                        # TODO: It could be improved to make only one request and avoid one per day
-                        currency_rate_obj._cron_update(date, date)
-                    # If after updating it does not exist, it will be loaded on the last available day
-                    if not currency_rate_obj.search([('name', '=', date)], limit=1):
-                        currency_rate_obj._create_the_latest_exchange_rate_to_date(self, date)
-                date += timedelta(days=1)
+        first_date = first_day.name if first_day else today
+
+        # Both sources accept a date range, so a single request covers every
+        # missing day instead of one request per day
+        currency_rate_obj._cron_update(first_date, today)
+
+        # Any day the source did not publish is loaded on the last available day
+        date = first_date
+        while date <= today:
+            if not currency_rate_obj.search([
+                ('name', '=', date),
+                ('currency_id', '=', self.id),
+            ], limit=1):
+                currency_rate_obj._create_the_latest_exchange_rate_to_date(self, date)
+            date += timedelta(days=1)
 
 
 class ResCurrencyRate(models.Model):
@@ -72,6 +93,67 @@ class ResCurrencyRate(models.Model):
     original_rate_2 = fields.Float(string='Buying Rate in Costa Rica', digits=(6, 2),
                                    help='The buying exchange rate from CRC to USD as it is send from BCCR')
 
+    def _bccr_get_series(self, indicator, first_date, last_date, token):
+        """Read one BCCR economic indicator from the SDDE REST API.
+
+        Returns {'YYYY-MM-DD': value} for the requested range. The BCCR
+        publishes a value for every calendar day, carrying the last published
+        one over weekends and holidays, so a single call fills a whole range
+        with no gaps. Returns an empty dict on any failure: this runs from a
+        cron and must not raise, but every failure is logged as an error so it
+        never goes unnoticed.
+        """
+        url = '%s/indicadoresEconomicos/%s/series' % (BCCR_API_BASE, indicator)
+        params = {
+            # The API rejects any other format with a 400
+            'fechaInicio': first_date.strftime('%Y/%m/%d'),
+            'fechaFin': last_date.strftime('%Y/%m/%d'),
+            # Omitting the language answers 404, it is not optional
+            'idioma': 'ES',
+        }
+        headers = {
+            'Authorization': 'Bearer %s' % token,
+            'Accept': 'application/json',
+            'User-Agent': BCCR_USER_AGENT,
+        }
+
+        try:
+            response = requests.get(url, params=params, headers=headers, timeout=BCCR_TIMEOUT)
+        except requests.exceptions.RequestException as e:
+            _logger.error("BCCR indicator %s: request failed: %s", indicator, e)
+            return {}
+
+        if response.status_code != 200:
+            _logger.error("BCCR indicator %s: HTTP %s - %s. Response: %s",
+                          indicator, response.status_code,
+                          BCCR_HTTP_ERRORS.get(response.status_code, "unexpected status"),
+                          response.text[:200])
+            return {}
+
+        try:
+            payload = response.json()
+        except ValueError:
+            _logger.error("BCCR indicator %s: response is not valid JSON: %s",
+                          indicator, response.text[:200])
+            return {}
+
+        series = {}
+        for indicator_data in payload.get('datos') or []:
+            for point in indicator_data.get('series') or []:
+                value = point.get('valorDatoPorPeriodo')
+                # The API sends null for days with no published value
+                if not value:
+                    continue
+                series[point['fecha'][:10]] = float(value)
+
+        # 'estado' comes back True even for an empty range, so the series are
+        # the only reliable sign that the query actually returned data
+        if not series:
+            _logger.error("BCCR indicator %s: no data between %s and %s (%s)", indicator,
+                          params['fechaInicio'], params['fechaFin'], payload.get('mensaje'))
+
+        return series
+
     @api.model
     def _cron_update(self, first_date=False, last_date=False):
 
@@ -81,91 +163,72 @@ class ResCurrencyRate(models.Model):
         exchange_source = self.env['ir.config_parameter'].sudo().get_param('exchange_source')
         if exchange_source == 'bccr':
             _logger.info("Getting exchange rates from BCCR")
-            bccr_username = self.env['ir.config_parameter'].sudo().get_param('bccr_username')
-            bccr_email = self.env['ir.config_parameter'].sudo().get_param('bccr_email')
             bccr_token = self.env['ir.config_parameter'].sudo().get_param('bccr_token')
+
+            if not bccr_token:
+                _logger.error("No BCCR token configured, generate one from the Indicadores "
+                              "Economicos site under Mi Perfil -> Generar token")
+                return False
 
             # Get current date to get exchange rate for today
             if first_date:
-                initial_date = first_date.strftime('%d/%m/%Y')
-                end_date = last_date.strftime('%d/%m/%Y')
+                initial_date = first_date
+                end_date = last_date or first_date
             else:
-                initial_date = datetime.now().date().strftime('%d/%m/%Y')
+                initial_date = datetime.now().date()
                 end_date = initial_date
 
-            # Web Service Connection using the XML schema from BCCRR
-            client = Client('https://gee.bccr.fi.cr/Indicadores/Suscripciones/WS/wsindicadoreseconomicos.asmx?WSDL')
+            selling_rates = self._bccr_get_series(
+                BCCR_SELLING_INDICATOR, initial_date, end_date, bccr_token)
+            buying_rates = self._bccr_get_series(
+                BCCR_BUYING_INDICATOR, initial_date, end_date, bccr_token)
 
-            response = client.service.ObtenerIndicadoresEconomicosXML(
-                Indicador='318', FechaInicio=initial_date, FechaFinal=end_date,
-                Nombre=bccr_username, SubNiveles='N', CorreoElectronico=bccr_email, Token=bccr_token)
+            currency_id = self.env.ref('base.USD')
 
-            xml_response = xml.etree.ElementTree.fromstring(response)
-            selling_rate_nodes = xml_response.findall("./INGC011_CAT_INDICADORECONOMIC")
+            # A rate is only complete when both indicators published that date,
+            # so pair them by date instead of walking both lists by position
+            incomplete_dates = set(selling_rates) ^ set(buying_rates)
+            if incomplete_dates:
+                _logger.error("Error loading currency rates, buying and selling rates don't "
+                              "match for %s", ', '.join(sorted(incomplete_dates)))
 
-            # Get Buying exchange Rate from BCCR
-            response = client.service.ObtenerIndicadoresEconomicosXML(
-                Indicador='317', FechaInicio=initial_date, FechaFinal=end_date,
-                Nombre=bccr_username, SubNiveles='N', CorreoElectronico=bccr_email, Token=bccr_token)
+            for current_date_str in sorted(set(selling_rates) & set(buying_rates)):
+                selling_original_rate = selling_rates[current_date_str]
+                buying_original_rate = buying_rates[current_date_str]
 
-            xml_response = xml.etree.ElementTree.fromstring(response)
-            buying_rate_nodes = xml_response.findall("./INGC011_CAT_INDICADORECONOMIC")
+                # Odoo uses the value of 1 unit of the base currency divided between the exchage rate
+                selling_rate = 1 / selling_original_rate
+                buying_rate = 1 / buying_original_rate
 
-            selling_rate = 0
-            buying_rate = 0
-            node_index = 0
-            if len(selling_rate_nodes) > 0 and len(selling_rate_nodes) == len(buying_rate_nodes):
-                while node_index < len(selling_rate_nodes):
-                    if selling_rate_nodes[node_index].find("DES_FECHA").text == \
-                       buying_rate_nodes[node_index].find("DES_FECHA").text:
-                        current_date_str = datetime.strptime(selling_rate_nodes[node_index].find("DES_FECHA").text,
-                                                             "%Y-%m-%dT%H:%M:%S-06:00").strftime('%Y-%m-%d')
+                # Get the rate for this date to know it is already registered
+                rates_ids = self.env['res.currency.rate'].search([
+                    ('name', '=', current_date_str),
+                    ('currency_id', '=', currency_id.id),
+                ], limit=1)
 
-                        selling_original_rate = float(selling_rate_nodes[node_index].find("NUM_VALOR").text)
-                        buying_original_rate = float(buying_rate_nodes[node_index].find("NUM_VALOR").text)
+                if len(rates_ids) > 0:
+                    rates_ids.write(
+                        {'rate': selling_rate,
+                         'original_rate': selling_original_rate,
+                         'rate_2': buying_rate,
+                         'original_rate_2': buying_original_rate,
+                         'currency_id': currency_id.id}
+                        )
+                else:
+                    self.create(
+                        {'name': current_date_str,
+                         'rate': selling_rate,
+                         'original_rate': selling_original_rate,
+                         'rate_2': buying_rate,
+                         'original_rate_2': buying_original_rate,
+                         'currency_id': currency_id.id})
 
-                        # Odoo uses the value of 1 unit of the base currency divided between the exchage rate
-                        selling_rate = 1 / selling_original_rate
-                        buying_rate = 1 / buying_original_rate
-
-                        # GET THE CURRENCY ID
-                        currency_id = self.env['res.currency'].search([('name', '=', 'USD')], limit=1)
-
-                        # Get the rate for this date to know it is already registered
-                        rates_ids = self.env['res.currency.rate'].search([('name', '=', current_date_str)], limit=1)
-
-                        if len(rates_ids) > 0:
-                            rates_ids.write(
-                                {'rate': selling_rate,
-                                 'original_rate': selling_original_rate,
-                                 'rate_2': buying_rate,
-                                 'original_rate_2': buying_original_rate,
-                                 'currency_id': currency_id.id}
-                                )
-                        else:
-                            self.create(
-                                {'name': current_date_str,
-                                 'rate': selling_rate,
-                                 'original_rate': selling_original_rate,
-                                 'rate_2': buying_rate,
-                                 'original_rate_2': buying_original_rate,
-                                 'currency_id': currency_id.id})
-
-                        _logger.info({'name': current_date_str,
-                                      'rate': selling_rate,
-                                      'original_rate': selling_original_rate,
-                                      'rate_2': buying_rate,
-                                      'original_rate_2': buying_original_rate,
-                                      'currency_id': currency_id.id})
-                    else:
-                        buy_des_fecha = buying_rate_nodes[node_index].find("DES_FECHA").text
-                        sell_des_fecha = selling_rate_nodes[node_index].find("DES_FECHA").text
-                        _logger.error("Error loading currency rates, dates for a buying (%s) ", buy_des_fecha)
-                        _logger.error("and selling (%s) rates don't match", sell_des_fecha)
-
-                    node_index += 1
-            else:
-                _logger.error("Error loading currency rates,dates range data for buying and selling rates don't match")
+                _logger.info({'name': current_date_str,
+                              'rate': selling_rate,
+                              'original_rate': selling_original_rate,
+                              'rate_2': buying_rate,
+                              'original_rate_2': buying_original_rate,
+                              'currency_id': currency_id.id})
 
         if exchange_source == 'hacienda':
             _logger.info("Getting exchange rates from HACIENDA")
@@ -253,7 +316,8 @@ class ResCurrencyRate(models.Model):
             ('name', '<=', name),
         ], limit=1, order='name desc')
 
-        if currency_rate_obj.name == name:
+        # With no earlier rate there is nothing to carry over
+        if not currency_rate_obj or currency_rate_obj.name == name:
             return
 
         self.create({
@@ -276,91 +340,70 @@ class ResCurrencyRate(models.Model):
         exchange_source = self.env['ir.config_parameter'].sudo().get_param('exchange_source')
         if exchange_source == 'bccr':
             _logger.info("Getting exchange rates from BCCR")
-            bccr_username = self.env['ir.config_parameter'].sudo().get_param('bccr_username')
-            bccr_email = self.env['ir.config_parameter'].sudo().get_param('bccr_email')
             bccr_token = self.env['ir.config_parameter'].sudo().get_param('bccr_token')
+
+            if not bccr_token:
+                _logger.error("No BCCR token configured, generate one from the Indicadores "
+                              "Economicos site under Mi Perfil -> Generar token")
+                return False
 
             # Get current date to get exchange rate for today
             if first_date:
-                initial_date = datetime.strptime(first_date, "%Y-%m-%d").strftime('%d/%m/%Y')
-                end_date = datetime.strptime(last_date, "%Y-%m-%d").strftime('%d/%m/%Y')
+                initial_date = datetime.strptime(first_date, "%Y-%m-%d")
+                end_date = datetime.strptime(last_date, "%Y-%m-%d")
             else:
-                initial_date = datetime.now().date().strftime('%d/%m/%Y')
+                initial_date = datetime.now().date()
                 end_date = initial_date
 
-            # Web Service Connection using the XML schema from BCCRR
-            client = Client('https://gee.bccr.fi.cr/Indicadores/Suscripciones/WS/wsindicadoreseconomicos.asmx?WSDL')
+            selling_rates = self._bccr_get_series(
+                BCCR_SELLING_INDICATOR, initial_date, end_date, bccr_token)
+            buying_rates = self._bccr_get_series(
+                BCCR_BUYING_INDICATOR, initial_date, end_date, bccr_token)
 
-            response = client.service.ObtenerIndicadoresEconomicosXML(
-                Indicador='318', FechaInicio=initial_date, FechaFinal=end_date,
-                Nombre=bccr_username, SubNiveles='N', CorreoElectronico=bccr_email, Token=bccr_token)
+            currency_id = self.env.ref('base.CRC')
 
-            xml_response = xml.etree.ElementTree.fromstring(response)
-            selling_rate_nodes = xml_response.findall("./INGC011_CAT_INDICADORECONOMIC")
+            incomplete_dates = set(selling_rates) ^ set(buying_rates)
+            if incomplete_dates:
+                _logger.error("Error loading currency rates, buying and selling rates don't "
+                              "match for %s", ', '.join(sorted(incomplete_dates)))
 
-            # Get Buying exchange Rate from BCCR
-            response = client.service.ObtenerIndicadoresEconomicosXML(
-                Indicador='317', FechaInicio=initial_date, FechaFinal=end_date,
-                Nombre=bccr_username, SubNiveles='N', CorreoElectronico=bccr_email, Token=bccr_token)
+            for current_date_str in sorted(set(selling_rates) & set(buying_rates)):
+                selling_rate = selling_rates[current_date_str]
+                buying_rate = buying_rates[current_date_str]
 
-            xml_response = xml.etree.ElementTree.fromstring(response)
-            buying_rate_nodes = xml_response.findall("./INGC011_CAT_INDICADORECONOMIC")
+                # Odoo uses the value of 1 unit of the base currency divided between the exchage rate
+                selling_original_rate = 1 / selling_rate
+                buying_original_rate = 1 / buying_rate
 
-            selling_rate = 0
-            buying_rate = 0
-            node_index = 0
-            if len(selling_rate_nodes) > 0 and len(selling_rate_nodes) == len(buying_rate_nodes):
-                while node_index < len(selling_rate_nodes):
-                    if selling_rate_nodes[node_index].find("DES_FECHA").text == \
-                       buying_rate_nodes[node_index].find("DES_FECHA").text:
-                        current_date_str = datetime.strptime(selling_rate_nodes[node_index].find("DES_FECHA").text,
-                                                             "%Y-%m-%dT%H:%M:%S-06:00").strftime('%Y-%m-%d')
+                # Get the rate for this date to know it is already registered
+                rates_ids = self.env['res.currency.rate'].search([
+                    ('name', '=', current_date_str),
+                    ('currency_id', '=', currency_id.id),
+                ], limit=1)
 
-                        selling_rate = float(selling_rate_nodes[node_index].find("NUM_VALOR").text)
-                        buying_rate = float(buying_rate_nodes[node_index].find("NUM_VALOR").text)
+                if len(rates_ids) > 0:
+                    rates_ids.write(
+                        {'rate': selling_rate,
+                         'original_rate': selling_original_rate,
+                         'rate_2': buying_rate,
+                         'original_rate_2': buying_original_rate,
+                         'currency_id': currency_id.id}
+                        )
+                else:
+                    self.create(
+                        {'name': current_date_str,
+                         'rate': selling_rate,
+                         'original_rate': selling_original_rate,
+                         'rate_2': buying_rate,
+                         'original_rate_2': buying_original_rate,
+                         'currency_id': currency_id.id})
 
-                        # Odoo uses the value of 1 unit of the base currency divided between the exchage rate
-                        selling_original_rate = 1 / selling_rate
-                        buying_original_rate = 1 / buying_rate
-
-                        # GET THE CURRENCY ID
-                        currency_id = self.env['res.currency'].search([('name', '=', 'CRC')], limit=1)
-
-                        # Get the rate for this date to know it is already registered
-                        rates_ids = self.env['res.currency.rate'].search([('name', '=', current_date_str)], limit=1)
-
-                        if len(rates_ids) > 0:
-                            rates_ids.write(
-                                {'rate': selling_rate,
-                                 'original_rate': selling_original_rate,
-                                 'rate_2': buying_rate,
-                                 'original_rate_2': buying_original_rate,
-                                 'currency_id': currency_id.id}
-                                )
-                        else:
-                            self.create(
-                                {'name': current_date_str,
-                                 'rate': selling_rate,
-                                 'original_rate': selling_original_rate,
-                                 'rate_2': buying_rate,
-                                 'original_rate_2': buying_original_rate,
-                                 'currency_id': currency_id.id})
-
-                        _logger.info({'name': current_date_str,
-                                      'rate': selling_rate,
-                                      'original_rate': selling_original_rate,
-                                      'rate_2': buying_rate,
-                                      'original_rate_2': buying_original_rate,
-                                      'currency_id': currency_id.id})
-                    else:
-                        buy_des_fecha = buying_rate_nodes[node_index].find("DES_FECHA").text
-                        sell_des_fecha = selling_rate_nodes[node_index].find("DES_FECHA").text
-                        _logger.error("Error loading currency rates, dates for a buying (%s) ", buy_des_fecha)
-                        _logger.error("and selling (%s) rates don't match", sell_des_fecha)
-
-                    node_index += 1
-            else:
-                _logger.error("Error loading currency rates,dates range data for buying and selling rates don't match")
+                _logger.info({'name': current_date_str,
+                              'rate': selling_rate,
+                              'original_rate': selling_original_rate,
+                              'rate_2': buying_rate,
+                              'original_rate_2': buying_original_rate,
+                              'currency_id': currency_id.id})
 
         if exchange_source == 'hacienda':
             _logger.info("Getting exchange rates from HACIENDA")

--- a/res_currency_cr_adapter/views/res_config_settings_views.xml
+++ b/res_currency_cr_adapter/views/res_config_settings_views.xml
@@ -9,11 +9,9 @@
                 <xpath expr="//field[@name='currency_exchange_journal_id']" position="after">
                         <div class="o_form_label col-lg-4 o_light_label">Origen del tipo de cambio</div>
                         <field name="exchange_source" string="Origen del tipo de cambio" class="o_form_label col-lg-4 o_light_label"/>
-                        <div attrs="{'invisible':[('exchange_source', '!=', 'bccr')]}" class="o_form_label col-lg-4 o_light_label">Username registered in the BCCR</div>
-                        <field attrs="{'invisible':[('exchange_source', '!=', 'bccr')]}" name="bccr_username" string="User name registered in the BCCR" />
                         <div attrs="{'invisible':[('exchange_source', '!=', 'bccr')]}" class="o_form_label col-lg-4 o_light_label">Email registered in the BCCR</div>
                         <field attrs="{'invisible':[('exchange_source', '!=', 'bccr')]}" name="bccr_email" string="email registered in the BCCR" />
-                        <div attrs="{'invisible':[('exchange_source', '!=', 'bccr')]}" class="o_form_label col-lg-4 o_light_label">BCCR Token</div>
+                        <div attrs="{'invisible':[('exchange_source', '!=', 'bccr')]}" class="o_form_label col-lg-4 o_light_label">Token BCCR (Mi Perfil → Generar token)</div>
                         <field attrs="{'invisible':[('exchange_source', '!=', 'bccr')]}" name="bccr_token" string="BCCR Token" password="True" />
                 </xpath>
            </field>


### PR DESCRIPTION
The SOAP service wsindicadoreseconomicos.asmx was retired and answers 503, so every BCCR run failed. Replace it with the SDDE REST API, mandatory since 2025-04-07.

- Read indicators 317/318 from apim.bccr.fi.cr/SDDE/api/Bccr.GE.SDDE.Publico.Indicadores.API through a new _bccr_get_series helper, authenticated with a bearer token instead of the old subscription parameters. Drop zeep and the XML parsing.
- Send an explicit User-Agent: the gateway answers 403 to the default one of the requests library, which is why the BCCR sets one on its own example.
- Pair both indicators by date instead of walking two lists by position, and report the dates that came incomplete rather than discarding the whole run.
- Check that the payload carries series: 'estado' is True even for an empty range. Skip null values before inverting them.
- Filter the existing rate lookup by currency, it could overwrite the rate of another currency on the same date.
- Log every failure as an error, with the causes documented on Anexo C of the standard, so a cron run can no longer fail silently.
- Fix action_create_missing_exchange_rates, which crashed on datetime.date.today(), and let it fill the whole range in a single request now that the API returns a value for every calendar day.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged: