### PR TITLE
[FIX] Restore right-elements div in Costa Rica invoice report templates

### DIFF
--- a/cr_electronic_invoice/views/report_invoice_document.xml
+++ b/cr_electronic_invoice/views/report_invoice_document.xml
@@ -155,7 +155,7 @@
                         </tbody>
                     </table>
 
-                    <div class="clearfix">
+                    <div id="right-elements" class="clearfix">
                         <div id="total" class="row">
                             <div t-attf-class="#{'col-6' if report_type != 'html' else 'col-sm-7 col-md-6'} ml-auto">
                                 <table class="table table-sm" style="page-break-inside: avoid;">

--- a/cr_electronic_invoice_qweb_fe/views/report_sales_invoice_qweb.xml
+++ b/cr_electronic_invoice_qweb_fe/views/report_sales_invoice_qweb.xml
@@ -502,6 +502,7 @@ _____________________<br/>
 Firma
                         </td>
                         <td style="border:1px solid black;" class="text-right">
+                            <div id="right-elements">
                             <table class="table table-sm">
                                 <tr class="border-black o_subtotal" style="">
                                     <td>
@@ -550,6 +551,7 @@ Firma
                                     </td>
                                 </tr>
                             </table>
+                            </div>
                         </td>
                     </tr>
                 </table>


### PR DESCRIPTION
## Summary
- `cr_electronic_invoice` and `cr_electronic_invoice_qweb_fe` both fully replace `account.report_invoice_document` instead of extending it via xpath, and neither replacement kept the `<div id="right-elements">` wrapper around the invoice totals that core/other addons (e.g. `stock_account`) xpath into.
- Adds `id="right-elements"` to the existing totals wrapper in `cr_electronic_invoice`'s template, and wraps the totals table in a new `<div id="right-elements">` in `cr_electronic_invoice_qweb_fe`'s template (its totals live inside a `<td>`, which can't itself carry the id since the xpath requires a `div`).
- Fixes install failure when installing `stock`/`stock_account` on top of these modules:
  `El elemento "<xpath expr="//div[@id='right-elements']">" no se puede localizar en la vista principal`

## Test plan
- [ ] Upgrade `cr_electronic_invoice` and `cr_electronic_invoice_qweb_fe` on a database that has them installed
- [ ] Install `stock` and confirm no ParseError on `stock_account_report_invoice_document`
- [ ] Print/preview a customer invoice PDF and confirm totals section still renders correctly for both CR invoice layouts