### PR TITLE
[fix] cr_electronic_invoice: hide FE fields and block Hacienda calls when disabled

### DIFF
--- a/cr_electronic_invoice/models/account_move.py
+++ b/cr_electronic_invoice/models/account_move.py
@@ -461,6 +461,8 @@ class AccountInvoiceElectronic(models.Model):
 
     def send_mrs_to_hacienda(self):
         for inv in self:
+            if inv.company_id.frm_ws_ambiente == 'disabled':
+                continue
             if inv.xml_supplier_approval:
 
                 # Verificar si el MR ya fue enviado y estamos esperando la confirmación
@@ -664,7 +666,7 @@ class AccountInvoiceElectronic(models.Model):
     @api.model
     # cron Job that verifies if the invoices are Validated at Tributación
     def _check_hacienda_for_invoices(self, max_invoices=10):
-        for company in self.env['res.company'].search([]):
+        for company in self.env['res.company'].search([('frm_ws_ambiente', '!=', 'disabled')]):
             self.with_company(company)._check_hacienda_for_invoices_company(company, max_invoices)
 
     def _check_hacienda_for_invoices_company(self, company, max_invoices=10):
@@ -832,7 +834,7 @@ class AccountInvoiceElectronic(models.Model):
 
     @api.model
     def _check_hacienda_for_mrs(self, max_invoices=10):  # cron
-        for company in self.env['res.company'].search([]):
+        for company in self.env['res.company'].search([('frm_ws_ambiente', '!=', 'disabled')]):
             self.with_company(company)._check_hacienda_for_mrs_company(company, max_invoices)
 
     def _check_hacienda_for_mrs_company(self, company, max_invoices=10):
@@ -913,6 +915,8 @@ class AccountInvoiceElectronic(models.Model):
 
         for inv in invoices:
             try:
+                if inv.company_id.frm_ws_ambiente == 'disabled':
+                    continue
                 current_invoice += 1
                 days_left = inv.company_id.get_days_left()
                 message = inv.company_id.get_message_to_send()
@@ -1630,6 +1634,8 @@ class AccountInvoiceElectronic(models.Model):
                 self.partner_id = cliente.id
     
     def get_new_partner_economic_activities(self, partner):
+        if self.company_id.frm_ws_ambiente == 'disabled':
+            return
         json_response = api_facturae.get_economic_activities(partner)
         if json_response["status"] == 200:
             activities = json_response["activities"]

--- a/cr_electronic_invoice/models/account_payment.py
+++ b/cr_electronic_invoice/models/account_payment.py
@@ -36,6 +36,8 @@ class AccountPayment(models.Model):
     
     
     def consult_rep_document(self):
+        if self.move_id.company_id.frm_ws_ambiente == 'disabled':
+            return
         token_m_h = api_facturae.get_token_hacienda(self.move_id, self.move_id.company_id.frm_ws_ambiente)
         response_json_consulta_clave = api_facturae.consulta_clave(self.clave, token_m_h, self.move_id.company_id.frm_ws_ambiente)
                 

--- a/cr_electronic_invoice/models/res_company.py
+++ b/cr_electronic_invoice/models/res_company.py
@@ -218,6 +218,8 @@ class CompanyElectronic(models.Model):
             self.write(to_write)
 
     def test_get_token(self):
+        if self.frm_ws_ambiente == 'disabled':
+            return
         self.get_expiration_date()
         token_m_h = api_facturae.get_token_hacienda(
             self.env.user, self.frm_ws_ambiente)

--- a/cr_electronic_invoice/models/res_partner.py
+++ b/cr_electronic_invoice/models/res_partner.py
@@ -35,6 +35,18 @@ class PartnerElectronic(models.Model):
     export = fields.Boolean(string="It's export", default=False)
     exoneration_article = fields.Char(string="Exoneration Article", help="Número de artículo que establece la exoneración")
     exoneration_clause = fields.Char(string="Exoneration Clause", help="Número de inciso que establece la exoneración o autorización")
+    frm_ws_ambiente = fields.Selection(
+        selection=[('disabled', 'Deshabilitado'),
+                  ('api-stag', 'Pruebas'),
+                  ('api-prod', 'Producción')],
+        string="Environment",
+        compute="_compute_frm_ws_ambiente",
+    )
+
+    def _compute_frm_ws_ambiente(self):
+        ambiente = self.env.company.frm_ws_ambiente
+        for partner in self:
+            partner.frm_ws_ambiente = ambiente
 
     @api.onchange('phone')
     def _onchange_phone(self):
@@ -98,6 +110,8 @@ class PartnerElectronic(models.Model):
                                           'sin ceros al inicio y sin guiones.'))
 
     def action_get_economic_activities(self):
+        if self.env.company.frm_ws_ambiente == 'disabled':
+            return
         if self.vat:
             json_response = api_facturae.get_economic_activities(self)
             _logger.debug('E-INV CR  - Economic Activities: %s', json_response)

--- a/cr_electronic_invoice/views/account_move_reversal_views.xml
+++ b/cr_electronic_invoice/views/account_move_reversal_views.xml
@@ -9,11 +9,11 @@
 
             <xpath expr="//field[@name='reason']" position="before">
                 <field name="reference_code_id" string="Código Referencia"
-                    invisible="move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund')"
-                    required="move_type in ('out_refund', 'in_refund')"/>
+                    invisible="move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund') or company_id.frm_ws_ambiente == 'disabled'"
+                    required="move_type in ('out_refund', 'in_refund') and company_id.frm_ws_ambiente != 'disabled'"/>
                 <field name="reference_document_id" string="Documento Referencia"
-                    invisible="move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund')"
-                    required="move_type in ('out_refund', 'in_refund')"/>
+                    invisible="move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund') or company_id.frm_ws_ambiente == 'disabled'"
+                    required="move_type in ('out_refund', 'in_refund') and company_id.frm_ws_ambiente != 'disabled'"/>
             </xpath>
 
             <xpath expr="//field[@name='reason']" position="attributes">

--- a/cr_electronic_invoice/views/account_move_views.xml
+++ b/cr_electronic_invoice/views/account_move_views.xml
@@ -52,11 +52,11 @@
                 <field name="tipo_documento"
                     readonly="state != 'draft'"
                     invisible="move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund')"
-                    required="move_type in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund')"/>
+                    required="move_type in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund') and company_id.frm_ws_ambiente != 'disabled'"/>
                 <field name="payment_methods_id"
                     readonly="state != 'draft'"
                     invisible="move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund')"
-                    required="move_type in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund')"/>
+                    required="move_type in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund') and company_id.frm_ws_ambiente != 'disabled'"/>
             </field>
 
             <xpath expr="//field[@name='invoice_line_ids']//list//field[@name='name']" position="after">
@@ -66,8 +66,9 @@
             </xpath>
 
             <xpath expr="//field[@name='invoice_line_ids']//list//field[@name='discount']" position="after">
+                <field name="company_id" column_invisible="True"/>
                 <field name="discount_note" optional="hide" />
-                <field name="discount_code_id" optional="hide" required="discount != 0"/>
+                <field name="discount_code_id" optional="hide" required="discount != 0 and company_id.frm_ws_ambiente != 'disabled'"/>
                 <field name="discount_code_code" column_invisible="True"/>
                 <field name="other_discount_code" invisible="discount_code_code != '99'" optional="hide"/>
                 <field name="tariff_head"/>

--- a/cr_electronic_invoice/views/account_move_views.xml
+++ b/cr_electronic_invoice/views/account_move_views.xml
@@ -34,8 +34,8 @@
             <field name="partner_id" position="after">
                 <field name="economic_activities_ids" invisible="1" readonly="1" options='{"active_test": [("type","in", ("in_invoice", "in_refund"))]}'/>
                 <field name="economic_activity_id"
-                    required="move_type in ('out_invoice', 'out_refund')"
-                    invisible="move_type not in ('out_invoice', 'out_refund') and tipo_documento != 'FEC'"
+                    required="move_type in ('out_invoice', 'out_refund') and company_id.frm_ws_ambiente != 'disabled'"
+                    invisible="(move_type not in ('out_invoice', 'out_refund') and tipo_documento != 'FEC') or company_id.frm_ws_ambiente == 'disabled'"
                     domain="[('id', 'in', economic_activities_ids),]"
                     options='{"no_open": True, "no_create": True, "active_test": [("type","in", ("in_invoice", "in_refund"))]}'/>
                 <field name="show_exoneration" invisible="1"/>
@@ -83,7 +83,7 @@
             </xpath>
 
             <xpath expr="//page[2]" position="after">
-                <page name="fe_invoice_data" string="Electronic Information" invisible="move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund')">
+                <page name="fe_invoice_data" string="Electronic Information" invisible="move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund') or (move_type in ('out_invoice', 'out_refund') and company_id.frm_ws_ambiente == 'disabled')">
                     <group id="fe_tab_group" col="2">
                         <group string="Electronic Acceptance" name="fe_in_info_group" colspan="2" col="5" invisible="tipo_documento == 'FEC' or move_type in ('out_invoice', 'out_refund')">
                             <field name="fname_xml_supplier_approval" invisible="1" colspan="5" />
@@ -91,7 +91,7 @@
                             <button name="load_xml_data" type="object" string="Cargar datos del XML" colspan="1" invisible="xml_supplier_approval == False or move_type in ('out_invoice', 'out_refund') or tipo_documento == 'FEC' or state != 'draft'"/>
                             <field name="state_invoice_partner" colspan="5" invisible="move_type in ('out_invoice', 'out_refund') or tipo_documento == 'FEC'"/>
                         </group>
-                        <group name="eref_info_group" colspan="2">
+                        <group name="eref_info_group" colspan="2" invisible="company_id.frm_ws_ambiente == 'disabled'">
                             <group string="Electronic Document Reference" name="eref_info_group1" colspan="2">
                                 <field name="reference_code_id" readonly="state != 'draft'"/>
                                 <field name="reference_document_id" readonly="state != 'draft'"/>

--- a/cr_electronic_invoice/views/res_company_views.xml
+++ b/cr_electronic_invoice/views/res_company_views.xml
@@ -25,9 +25,9 @@
             </field>
 
             <field name="currency_id" position="after">
-                <field name="activity_id" domain="[('id', 'in', economic_activity_ids)]" options='{"no_open": True, "no_create": True}' />
-                <button name="action_get_economic_activities" type="object" string="Consultar Actividad Economica en Hacienda" colspan="2" />
-                <field name="economic_activity_ids" colspan="2" options='{"no_create": True}'>
+                <field name="activity_id" domain="[('id', 'in', economic_activity_ids)]" options='{"no_open": True, "no_create": True}' invisible="frm_ws_ambiente == 'disabled'"/>
+                <button name="action_get_economic_activities" type="object" string="Consultar Actividad Economica en Hacienda" colspan="2" invisible="frm_ws_ambiente == 'disabled'"/>
+                <field name="economic_activity_ids" colspan="2" options='{"no_create": True}' invisible="frm_ws_ambiente == 'disabled'">
                     <list>
                         <field name="code"/>
                         <field name="name"/>
@@ -70,7 +70,7 @@
             <xpath expr="//page[1]" position="after">
                 <page string="Electronic Invoice">
                     <group cols="2">
-                        <group cols="2">
+                        <group cols="2" invisible="frm_ws_ambiente == 'disabled'">
                             <field name="signature"/>
                             <field name="frm_ws_identificador"/>
                             <field name="frm_ws_password" password="True"/>
@@ -81,17 +81,17 @@
                             <field name="to_emails"/>
                         </group>
                         <group cols="2">
-                            <button name="test_get_token" type="object" string="Test get token" colspan="2" />
+                            <button name="test_get_token" type="object" string="Test get token" colspan="2" invisible="frm_ws_ambiente == 'disabled'"/>
                             <field name="frm_ws_ambiente" widget="radio"/>
                         </group>
-                        <group cols="2">
+                        <group cols="2" invisible="frm_ws_ambiente == 'disabled'">
                             <field name="CCE_sequence_id"/>
                             <field name="CPCE_sequence_id"/>
                             <field name="RCE_sequence_id"/>
                             <field name="FEC_sequence_id"/>
                         </group>
 
-                        <group cols="2">
+                        <group cols="2" invisible="frm_ws_ambiente == 'disabled'">
                             <field name="sucursal_MR"/>
                             <field name="terminal_MR"/>
                         </group>

--- a/cr_electronic_invoice/views/res_partner_views.xml
+++ b/cr_electronic_invoice/views/res_partner_views.xml
@@ -19,7 +19,8 @@
             </field>
 
             <xpath expr="//form/sheet/notebook" position="before">
-                <group col="7" groups="account.group_account_user,account.group_account_readonly">
+                <field name="frm_ws_ambiente" invisible="1"/>
+                <group col="7" groups="account.group_account_user,account.group_account_readonly" invisible="frm_ws_ambiente == 'disabled'">
                     <separator colspan="7"/>
                     <field name="activity_id" domain="[('id', 'in', economic_activities_ids)]" options="{&quot;no_create&quot;: True, &quot;active_test&quot;: False}" colspan="5" />
                     <button name="action_get_economic_activities" type="object" string="Consultar Actividad Economica en Hacienda" colspan="2" />

--- a/cr_electronic_invoice/wizard/account_move_reversal.py
+++ b/cr_electronic_invoice/wizard/account_move_reversal.py
@@ -8,8 +8,8 @@ class AccountMoveReversal(models.TransientModel):
     Account move reversal wizard, it cancel an account move by reversing it.
     """
 
-    reference_code_id = fields.Many2one("reference.code", string="Reference Code", required=True)
-    reference_document_id = fields.Many2one("reference.document", string="Reference Document", required=True)
+    reference_code_id = fields.Many2one("reference.code", string="Reference Code")
+    reference_document_id = fields.Many2one("reference.document", string="Reference Document")
 
     def _prepare_default_reversal(self, move):
         default_values = super()._prepare_default_reversal(move)

--- a/cr_electronic_invoice/wizard/account_payment_register.py
+++ b/cr_electronic_invoice/wizard/account_payment_register.py
@@ -23,6 +23,9 @@ class AccountPaymentRegister(models.TransientModel):
                 continue
             invoice = invoice[0]
 
+            if invoice.company_id.frm_ws_ambiente == 'disabled':
+                continue
+
             sucursal_id = payment.move_id.journal_id.sucursal or self.env.user.company_id.sucursal_MR
             terminal_id = payment.move_id.journal_id.terminal or self.env.user.company_id.terminal_MR
             sequence = self.env['ir.sequence'].next_by_code('sequence.REP')

--- a/cr_electronic_invoice_pos/models/electronic_invoice.py
+++ b/cr_electronic_invoice_pos/models/electronic_invoice.py
@@ -271,6 +271,8 @@ class PosOrder(models.Model):
         _logger.info(
             'E-INV CR - Consulta Hacienda - POS Orders to check: %s', total_orders)
         for doc in pos_orders:
+            if doc.company_id.frm_ws_ambiente == 'disabled':
+                continue
             current_order += 1
             _logger.info(
                 'E-INV CR - Consulta Hacienda - POS Order %s / %s', current_order, total_orders)


### PR DESCRIPTION
## Summary
- When a company's `frm_ws_ambiente` (electronic invoicing environment) is set to `disabled`, hide all FE-only fields on `res.partner` (economic activity), `res.company` (credentials, sequences, sucursal/terminal, economic activity), and `account.move` (`economic_activity_id`, the `fe_invoice_data` page) — and make sure none of them are required while hidden.
- For vendor bills (`in_invoice`/`in_refund`), the `fe_invoice_data` page stays visible but reduced to the "Electronic Acceptance" group, since importing a vendor invoice from XML via `load_xml_data` must keep working regardless of the disabled setting.
- Audited every call site into `api_facturae` (token requests, document consultation, XML send, economic-activity lookups) across `account_move.py`, `account_payment.py`, `res_company.py`, `res_partner.py`, the payment-register wizard, and the POS module, and added `frm_ws_ambiente == 'disabled'` guards to every one that was previously unguarded, so no live Hacienda communication happens for a disabled company.
- Full-module audit also found `account.move.reversal`'s `reference_code_id`/`reference_document_id` were `required=True` unconditionally at the Python level (blocking reversal of any move, including plain journal entries, regardless of company). Dropped the hard requirement and gated it in the view instead, along with `account.move`'s `tipo_documento`, `payment_methods_id`, and line-level `discount_code_id`, which had required conditions but no `frm_ws_ambiente` gate.

## Test plan
- [ ] Set a company's `frm_ws_ambiente` to `disabled`; confirm the FE fields/pages listed above are hidden on partner/company/invoice forms and don't block saving.
- [ ] With `frm_ws_ambiente` disabled, confirm a vendor bill can still import data from an uploaded XML via "Cargar datos del XML".
- [ ] With `frm_ws_ambiente` disabled, confirm posting/reversing invoices and journal entries does not attempt any Hacienda API call and does not raise validation errors for the now-optional FE fields.
- [ ] Re-enable `frm_ws_ambiente` and confirm the existing e-invoicing flow (sending, consulting Hacienda, sequences) still works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)