### PR TITLE
[FIX] cr_electronic_invoice: fix invoice print KeyError on 19.0 tax_totals schema

### DIFF
--- a/cr_electronic_invoice/views/report_invoice_document.xml
+++ b/cr_electronic_invoice/views/report_invoice_document.xml
@@ -24,6 +24,26 @@
                     </div>
                 </t>
                 <div class="page">
+                    <!-- 19-port: wrapped in <t t-set="layout_document_title"> - core's
+                         account_edi_ubl_cii module (auto_install=True alongside account,
+                         so always present) xpath-inherits account.report_invoice_document
+                         targeting //t[@t-set='layout_document_title'] to insert its own
+                         <t t-set="address"> block (company-details/VAT for UBL compliance)
+                         right before it. Since this template fully replaces (not
+                         xpath-inherits) the base template, that anchor didn't exist here,
+                         crashing the whole registry load.
+                         GENUINE OPEN QUESTION for a human, not guessed at: that UBL
+                         insertion re-sets the same "address" variable this template
+                         already sets above (lines ~7-25, customer/payment/currency/tax-ID
+                         block) - in QWeb the later t-set wins, so account_edi_ubl_cii's
+                         company-details block would silently replace Costa Rica's
+                         customer-address block in the actual rendered PDF once this
+                         anchor exists. Needs a real decision (and visual PDF check) on
+                         whether UBL e-invoicing should even be reachable for CR invoices
+                         at all, given cr_electronic_invoice already provides Costa Rica's
+                         own government-mandated structured e-invoice format separately -
+                         not resolved here, only unblocked from crashing. -->
+                    <t t-set="layout_document_title">
                     <h2>
                         <span t-if="o.move_type == 'out_invoice' and o.state == 'posted'">Invoice</span>
                         <span t-if="o.move_type == 'out_invoice' and o.state == 'draft'">Draft Invoice</span>
@@ -33,6 +53,8 @@
                         <span t-if="o.move_type == 'in_invoice'">Vendor Bill</span>
                         <span t-if="o.name != '/'" t-field="o.name"/>
                     </h2>
+                    </t>
+                    <t t-raw="layout_document_title"/>
                     <div id="electronic_data" class="row mt32 mb32">
                         <div class="col-auto col-3 mw-100 mb-2" t-if="o.number_electronic" name="number_electronic">
                             <strong>Electronic Number:</strong>
@@ -159,34 +181,20 @@
                         <div id="total" class="row">
                             <div t-attf-class="#{'col-6' if report_type != 'html' else 'col-sm-7 col-md-6'} ml-auto">
                                 <table class="table table-sm" style="page-break-inside: avoid;">
-                                    <tr class="border-black o_subtotal" style="">
-                                        <td><strong>Subtotal</strong></td>
-                                        <td class="text-right">
-                                            <span t-field="o.amount_untaxed"/>
-                                        </td>
-                                    </tr>
-                                    <t t-foreach="o.tax_totals['groups_by_subtotal'][subtotal_to_show]" t-as="amount_by_group">
-                                        <tr style="">
-                                            <t t-if="len(o.line_ids.filtered(lambda line: line.tax_line_id)) in [0, 1] and o.amount_untaxed == amount_by_group[2]">
-                                                <td>
-                                                    <span class="text-nowrap" t-esc="amount_by_group[0]"/>
-                                                </td>
-                                                <td class="text-right o_price_total">
-                                                    <span class="text-nowrap" t-esc="amount_by_group[3]" />
-                                                </td>
-                                            </t>
-                                            <t t-else="">
-                                                <td>
-                                                    <span t-esc="amount_by_group[0]"/>
-                                                    <span class="text-nowrap"> on
-                                                        <t t-esc="amount_by_group[4]"/>
-                                                    </span>
-                                                </td>
-                                                <td class="text-right o_price_total">
-                                                    <span class="text-nowrap" t-esc="amount_by_group[3]"/>
-                                                </td>
-                                            </t>
-                                        </tr>
+                                    <!-- 19-port: account.move.tax_totals dropped the old
+                                         16.0 {'groups_by_subtotal': {...}} dict shape (it's now
+                                         {'subtotals': [{'tax_groups': [...]}, ...], ...} - see
+                                         core's account.document_tax_totals_template). This
+                                         hand-rolled block hard-coded the old shape and raised
+                                         KeyError: 'groups_by_subtotal' on every invoice print.
+                                         Reuse core's own up-to-date template instead of
+                                         re-deriving the new schema by hand - it also already
+                                         renders the untaxed-amount subtotal row per tax group,
+                                         so the separate hard-coded "Subtotal" row above is
+                                         redundant and removed with it. -->
+                                    <t t-if="o.tax_totals" t-call="account.document_tax_totals">
+                                        <t t-set="tax_totals" t-value="o.tax_totals"/>
+                                        <t t-set="currency" t-value="o.currency_id"/>
                                     </t>
                                     <tr class="border-black o_total">
                                         <td><strong>Total</strong></td>
@@ -304,6 +312,13 @@
         <!-- EXTERNAL LAYOUT STANDART -->
         <template id="web.external_layout_standard">
             <div t-attf-class="header o_company_#{company.id}_layout" t-att-style="report_header_style">
+                <!-- 19-port: empty anchor, purely so account_edi_ubl_cii's
+                     layout_invoices_generated_by_odoo xpath (position="replace")
+                     has something to match - that template is only used to render
+                     the "Preview - this is not an official document" watermark
+                     view of a UBL XML attachment, not the real invoice PDF, so
+                     this anchor's own layout/content doesn't matter here. -->
+                <div class="d-flex justify-content-between" style="display:none"/>
                 <div class="row">
                     <div class="col-3 mb4">
                         <img t-if="company.logo" t-att-src="image_data_uri(company.logo)" style="max-height: 45px;" alt="Logo"/>


### PR DESCRIPTION
## Summary
- Fixes `KeyError: 'groups_by_subtotal'` raised every time an invoice is printed on Odoo 19.0 (reported from `qasecr.akurey.com`). `account.move.tax_totals` changed shape in 19.0 (16.0's `{'groups_by_subtotal': {...}}` became `{'subtotals': [{'tax_groups': [...]}], ...}`), and `cr_electronic_invoice` fully overrides `account.report_invoice_document` (instead of extending it via xpath), so its replacement template still hard-coded the old dict access.
- Replaces the hand-rolled totals block with a call to core's own `account.document_tax_totals` template, which already renders correctly against the current schema - this also drops a now-redundant hard-coded "Subtotal" row the old block duplicated.
- Bundled in the same file (already in the working tree from earlier 19.0-port work, not new in this PR): the `layout_document_title` anchor needed by `account_edi_ubl_cii`'s xpath inherit, and an empty anchor `div` in `web.external_layout_standard` for the same module's watermark-preview template - both were needed just to stop the registry from crashing on load; see the inline comments for the open question flagged on the UBL address-block overlap.

## Test plan
- [ ] Print/preview a customer invoice (out_invoice) with taxes on a 19.0 database and confirm the PDF renders without error
- [ ] Confirm the tax totals section shows the correct subtotal-per-tax-group and total amounts
- [ ] Spot-check a multi-tax-group invoice (e.g. IVA + exonerated line) still lays out correctly
- [ ] Confirm `stock`/`account_edi_ubl_cii` still install cleanly on top of this module (regression check for the related right-elements/anchor fixes already in this diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfT1zpND4fMTGCkg2GttGp