### PR TITLE
[FIX] cr_electronic_invoice: raw HTML tags shown in invoice tax column

### DIFF
--- a/cr_electronic_invoice/views/report_invoice_document.xml
+++ b/cr_electronic_invoice/views/report_invoice_document.xml
@@ -141,7 +141,13 @@
                                             <span class="text-nowrap" t-field="line.discount"/>
                                         </td>
                                         <td t-attf-class="text-left {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
-                                            <span t-esc="', '.join(map(lambda x: (x.description or x.name), line.tax_ids))" id="line_tax_ids"/>
+                                            <!-- 19-port: account.tax.description became an Html field
+                                                 (core auto-wraps plain text in a <div>), so t-esc'ing it
+                                                 printed the raw markup instead of the tax name. Core's own
+                                                 report switched to tax_label (a plain Char computed as
+                                                 invoice_label or name) for this exact column - use the
+                                                 same field instead of re-deriving a plaintext fallback. -->
+                                            <span t-esc="', '.join(map(lambda x: x.tax_label, line.tax_ids))" id="line_tax_ids"/>
                                         </td>
                                         <td class="text-right o_price_total">
                                             <span class="text-nowrap" t-field="line.price_subtotal" groups="account.group_show_line_subtotals_tax_excluded"/>

--- a/cr_electronic_invoice_qweb_fe/views/report_sales_invoice_qweb.xml
+++ b/cr_electronic_invoice_qweb_fe/views/report_sales_invoice_qweb.xml
@@ -452,7 +452,11 @@
                                     <span t-field="l.discount"/>
                                 </td>
                                 <td class="text-right">
-                                    <span t-if="l.tax_ids" t-esc="', '.join(map(lambda x: (x.description or x.name), l.tax_ids))"/>
+                                    <!-- 19-port: same fix as cr_electronic_invoice/views/report_invoice_document.xml -
+                                         account.tax.description became an Html field (core auto-wraps plain
+                                         text in a <div>), so t-esc'ing it printed the raw markup. Use
+                                         tax_label (plain Char, invoice_label or name) instead. -->
+                                    <span t-if="l.tax_ids" t-esc="', '.join(map(lambda x: x.tax_label, l.tax_ids))"/>
                                     <span t-if="not l.tax_ids">EXE</span>
                                 </td>
                                 <td class="text-right">


### PR DESCRIPTION
## Summary
- Fixes raw `<div>IVA General 13%</div>` markup printing literally in the "Impuestos" tax column of every invoice line (confirmed from a printed PDF on `qasecr.akurey.com`).
- `account.tax.description` became an `Html` field in Odoo 19.0 - core now auto-wraps plain text in a `<div>` when sanitizing it. Both `cr_electronic_invoice` and `cr_electronic_invoice_qweb_fe`'s invoice report templates still read `x.description or x.name` under a plain `t-esc`, so the raw HTML markup rendered as literal text instead of being interpreted.
- Switched both templates to `tax_label` - a plain `Char` field (computed as `invoice_label or name`) that core's own report already uses for this exact column - instead of re-deriving a plaintext fallback from the HTML field.

## Test plan
- [ ] Print/preview a customer invoice with taxed lines on 19.0 and confirm the "Impuestos" column shows the tax name (e.g. "IVA General 13%"), not raw HTML tags
- [ ] Same check for the electronic-invoice QWeb report (`cr_electronic_invoice_qweb_fe`)
- [ ] Spot-check a line with multiple taxes still comma-separates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfT1zpND4fMTGCkg2GttGp