### PR TITLE
[FIX] misc 19.0-port data fixes: taxes, load_lines, portal template, neighborhood csv

### DIFF
--- a/cr_electronic_invoice/data/account_tax_data.xml
+++ b/cr_electronic_invoice/data/account_tax_data.xml
@@ -79,6 +79,7 @@
 
     <!-- account tax -->
     <record id="iva_tax_0" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">01</field>
         <field name="name">IVA 0%</field>
         <field name="amount">0</field>
@@ -91,6 +92,7 @@
     </record>
 
     <record id="iva_tax_00" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">01</field>
         <field name="name">IVA 0% </field>
         <field name="amount">0</field>
@@ -103,6 +105,7 @@
     </record>
 
     <record id="iva_tax_00_ND" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">01</field>
         <field name="name">IVA 0% (No deducible)</field>
         <field name="amount">0</field>
@@ -116,6 +119,7 @@
     </record>
 
     <record id="iva_tax_01" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">01</field>
         <field name="name">IVA</field>
         <field name="amount">13</field>
@@ -128,6 +132,7 @@
     </record>
 
     <record id="iva_tax_02" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">01</field>
         <field name="name">IVA</field>
         <field name="amount">13</field>
@@ -140,6 +145,7 @@
     </record>
 
     <record id="iva_tax_02_ND" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">01</field>
         <field name="name">IVA 13% (No deducible)</field>
         <field name="amount">13</field>
@@ -153,6 +159,7 @@
     </record>
 
     <record id="iva_tax_03" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">01</field>
         <field name="name">IVA 1% (Tarifa Reducida)</field>
         <field name="amount">1</field>
@@ -165,6 +172,7 @@
     </record>
 
     <record id="iva_tax_04" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">01</field>
         <field name="name">IVA 1% (Tarifa Reducida)</field>
         <field name="amount">1</field>
@@ -177,6 +185,7 @@
     </record>
 
     <record id="iva_tax_04_ND" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">01</field>
         <field name="name">IVA 1% (No deducible)</field>
         <field name="amount">1</field>
@@ -190,6 +199,7 @@
     </record>
 
     <record id="iva_tax_05" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">01</field>
         <field name="name">IVA 2% (Tarifa Reducida)</field>
         <field name="amount">2</field>
@@ -202,6 +212,7 @@
     </record>
 
     <record id="iva_tax_06" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">01</field>
         <field name="name">IVA 2% (Tarifa Reducida)</field>
         <field name="amount">2</field>
@@ -214,6 +225,7 @@
     </record>
 
     <record id="iva_tax_06_ND" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">01</field>
         <field name="name">IVA 2% (No deducible)</field>
         <field name="amount">2</field>
@@ -227,6 +239,7 @@
     </record>
 
     <record id="iva_tax_07" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">01</field>
         <field name="name">IVA 4% (Tarifa Reducida)</field>
         <field name="amount">4</field>
@@ -239,6 +252,7 @@
     </record>
 
     <record id="iva_tax_08" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">01</field>
         <field name="name">IVA 4% (Tarifa Reducida)</field>
         <field name="amount">4</field>
@@ -251,6 +265,7 @@
     </record>
 
     <record id="iva_tax_08_ND" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">01</field>
         <field name="name">IVA 4% (No deducible)</field>
         <field name="amount">4</field>
@@ -264,6 +279,7 @@
     </record>
 
     <record id="iva_tax_09" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">01</field>
         <field name="name">IVA 0% (Transitorio)</field>
         <field name="amount">0</field>
@@ -276,6 +292,7 @@
     </record>
 
     <record id="iva_tax_10" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">01</field>
         <field name="name">IVA 0% (Transitorio)</field>
         <field name="amount">0</field>
@@ -288,6 +305,7 @@
     </record>
 
     <record id="iva_tax_10_ND" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">01</field>
         <field name="name">IVA 0% (Trans No deducible)</field>
         <field name="amount">0</field>
@@ -301,6 +319,7 @@
     </record>
 
     <record id="iva_tax_11" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">01</field>
         <field name="name">IVA 4% (Transitorio)</field>
         <field name="amount">4</field>
@@ -313,6 +332,7 @@
     </record>
 
     <record id="iva_tax_12" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">01</field>
         <field name="name">IVA 4% (Transitorio)</field>
         <field name="amount">4</field>
@@ -325,6 +345,7 @@
     </record>
 
     <record id="iva_tax_12_ND" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">01</field>
         <field name="name">IVA 4% (Trans No deducible)</field>
         <field name="amount">4</field>
@@ -338,6 +359,7 @@
     </record>
 
     <record id="iva_tax_13" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">01</field>
         <field name="name">IVA 8% (Transitorio)</field>
         <field name="amount">8</field>
@@ -350,6 +372,7 @@
     </record>
 
     <record id="iva_tax_14" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">01</field>
         <field name="name">IVA 8% (Transitorio)</field>
         <field name="amount">8</field>
@@ -362,6 +385,7 @@
     </record>
 
     <record id="iva_tax_14_ND" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">01</field>
         <field name="name">IVA 8% (Trans No deducible)</field>
         <field name="amount">8</field>
@@ -375,6 +399,7 @@
     </record>
 
     <record id="iva_tax_15" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">02</field>
         <field name="name">Impuesto Selectivo de Consumo</field>
         <field name="amount">0</field>
@@ -387,6 +412,7 @@
     </record>
 
     <record id="iva_tax_16" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">02</field>
         <field name="name">Impuesto Selectivo de Consumo</field>
         <field name="amount">0</field>
@@ -399,6 +425,7 @@
     </record>
 
     <record id="iva_tax_16_ND" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">02</field>
         <field name="name">Impuesto Selectivo de Consumo (No deducible)</field>
         <field name="amount">0</field>
@@ -412,6 +439,7 @@
     </record>
 
     <record id="iva_tax_17" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">03</field>
         <field name="name">Impuesto Único a los Combustibles</field>
         <field name="amount">0</field>
@@ -424,6 +452,7 @@
     </record>
 
     <record id="iva_tax_18" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">03</field>
         <field name="name">Impuesto Único a los Combustibles</field>
         <field name="amount">0</field>
@@ -436,6 +465,7 @@
     </record>
 
     <record id="iva_tax_19" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">04</field>
         <field name="name">Impuesto específico de Bebidas Alcohólicas</field>
         <field name="amount">0</field>
@@ -449,6 +479,7 @@
 
     <record id="iva_tax_20" 
         model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">04</field>
         <field name="name">Impuesto específico de Bebidas Alcohólicas</field>
         <field name="amount">0</field>
@@ -461,6 +492,7 @@
     </record>
 
     <record id="iva_tax_21" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">05</field>
         <field name="name">Impuesto Específico sobre las bebidas envasadas sin contenido alcohólico y jabones de tocador</field>
         <field name="amount">0</field>
@@ -473,6 +505,7 @@
     </record>
 
     <record id="iva_tax_22" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">05</field>
         <field name="name">Impuesto Específico sobre las bebidas envasadas sin contenido alcohólico y jabones de tocador</field>
         <field name="amount">0</field>
@@ -485,6 +518,7 @@
     </record>
 
     <record id="iva_tax_23" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">06</field>
         <field name="name">Impuesto a los Productos de Tabaco</field>
         <field name="amount">0</field>
@@ -497,6 +531,7 @@
     </record>
 
     <record id="iva_tax_24" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">06</field>
         <field name="name">Impuesto a los Productos de Tabaco</field>
         <field name="amount">0</field>
@@ -509,6 +544,7 @@
     </record>
 
     <record id="iva_tax_25" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">07</field>
         <field name="name">IVA (cálculo especial)</field>
         <field name="amount">0</field>
@@ -521,6 +557,7 @@
     </record>
 
     <record id="iva_tax_26" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">07</field>
         <field name="name">IVA (cálculo especial)</field>
         <field name="amount">0</field>
@@ -533,6 +570,7 @@
     </record>
 
     <record id="iva_tax_26_ND" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">07</field>
         <field name="name">IVA (cálculo especial - No deducible)</field>
         <field name="amount">0</field>
@@ -546,6 +584,7 @@
     </record>
 
     <record id="iva_tax_27" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">08</field>
         <field name="name">IVA Régimen de Bienes Usados (Factor)</field>
         <field name="amount">0</field>
@@ -558,6 +597,7 @@
     </record>
 
     <record id="iva_tax_28" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">08</field>
         <field name="name">IVA Régimen de Bienes Usados (Factor)</field>
         <field name="amount">0</field>
@@ -570,6 +610,7 @@
     </record>
 
     <record id="iva_tax_28_ND" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">08</field>
         <field name="name">IVA Régimen de Bienes Usados (Factor - No deducible)</field>
         <field name="amount">0</field>
@@ -583,6 +624,7 @@
     </record>
 
     <record id="iva_tax_29" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">12</field>
         <field name="name">Impuesto Específico al Cemento</field>
         <field name="amount">0</field>
@@ -594,6 +636,7 @@
     </record>
 
     <record id="iva_tax_30" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">12</field>
         <field name="name">Impuesto Específico al Cemento</field>
         <field name="amount">0</field>
@@ -605,6 +648,7 @@
     </record>
 
     <record id="iva_tax_31" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">99</field>
         <field name="name">Otros</field>
         <field name="amount">0</field>
@@ -616,6 +660,7 @@
     </record>
 
     <record id="iva_tax_32" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">99</field>
         <field name="name">Otros</field>
         <field name="amount">0</field>
@@ -627,6 +672,7 @@
     </record>
 
     <record id="iva_tax_32_ND" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">99</field>
         <field name="name">Otros (No deducible)</field>
         <field name="amount">0</field>
@@ -640,6 +686,7 @@
     </record>
 
     <record id="service_tax_sale" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">service</field>
         <field name="name">Impuesto de Servicio</field>
         <field name="amount">10</field>
@@ -652,6 +699,7 @@
     </record>
 
     <record id="exempt_tax_sale" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">00</field>
         <field name="name">Exento</field>
         <field name="amount">0</field>
@@ -664,6 +712,7 @@
     </record>
 
     <record id="exempt_tax_purchase" model="account.tax">
+        <field name="country_id" ref="base.cr"/>
         <field name="tax_code">00</field>
         <field name="name">Exento</field>
         <field name="amount">0</field>

--- a/cr_electronic_invoice/models/res_config_settings.py
+++ b/cr_electronic_invoice/models/res_config_settings.py
@@ -25,8 +25,18 @@ class ResConfigSettings(models.TransientModel):
         string="Default Analytic Account for expenses when loading data from XML",
         help="The analytic account used when loading Costa Rican digital invoice")
 
+    # 19-port migration: this field's own consuming code (account_move.py,
+    # api_facturae.py) reads its value via
+    # self.env['ir.config_parameter'].sudo().get_param('load_lines') - a
+    # global setting, not the company-scoped field-access pattern
+    # company_dependent=True implies. Confirmed via real production data:
+    # ir_model_fields never had company_dependent=True for this field before
+    # (checked pre-19.0 state), and there's no ir.property history for it
+    # either - company_dependent=True is a declaration/consumption mismatch
+    # in this checkout, not an intentional feature. Removed to match actual
+    # usage and keep the existing boolean column (Postgres can't auto-cast
+    # boolean to the jsonb type company_dependent=True requires in 19.0).
     load_lines = fields.Boolean(
         string='Indicates if invoice lines should be load when loading a Costa Rican Digital Invoice',
-        company_dependent=True,
         default=True
     )

--- a/cr_electronic_invoice/views/account_portal_templates.xml
+++ b/cr_electronic_invoice/views/account_portal_templates.xml
@@ -92,6 +92,18 @@
                                 </div>
                             </li>
                         </ul>
+                        <!-- 19-port: empty (not hidden - display:none would also
+                             hide anything xpath-inserted after it) anchor, purely
+                             so sale_timesheet.portal_invoice_page_inherit's xpath
+                             (//t[@t-set='entries']/div/div/div[hasclass('o_download_pdf')],
+                             position="after") has something to match - this
+                             template fully replaces (not xpath-inherits)
+                             account.portal_invoice_page, using a real ul/li/div
+                             structure instead of core's div/div/div, so
+                             sale_timesheet's exact-path xpath could never match it
+                             as-is. Its "View Timesheets" button will render right
+                             after this (empty, so visually a no-op) anchor. -->
+                        <div><div><div class="o_download_pdf"/></div></div>
                     </t>
                 </t>
 

--- a/l10n_cr_country_codes/data/res.country.neighborhood.csv
+++ b/l10n_cr_country_codes/data/res.country.neighborhood.csv
@@ -75,7 +75,7 @@ neighborhood_Cornelia_Patalillo_Vásquez_de_Coronado_SJ,01,Cornelia,district_Pat
 neighborhood_Avilés_Cascajal_Vásquez_de_Coronado_SJ,01,Avilés,district_Cascajal_Vásquez_de_Coronado_SJ
 neighborhood_Abarca_San_Ignacio_Acosta_SJ,01,Abarca,district_San_Ignacio_Acosta_SJ
 neighborhood_Alto_Sierra_Guaitil_Villa_Acosta_SJ,01,Alto Sierra,district_Guaitil_Villa_Acosta_SJ
-neighborhood_San_Pablo_Palmichal_Acosta_SJ,01,San Pablo,district_Palmichal_Acosta_SJ
+neighborhood_San_Pablo_Palmichal_Acosta_SJ_01,01,San Pablo,district_Palmichal_Acosta_SJ
 neighborhood_Bajo_Los_Cruces_Cangrejal_Acosta_SJ,01,Bajo Los Cruces,district_Cangrejal_Acosta_SJ
 neighborhood_Alto_Parritón_Sabanillas_Acosta_SJ,01,Alto Parritón,district_Sabanillas_Acosta_SJ
 neighborhood_Acacias_San_Juan_Tibás_SJ,01,Acacias,district_San_Juan_Tibás_SJ
@@ -1659,7 +1659,7 @@ neighborhood_Guayabal_Canoas_Corredores_P,15,Guayabal,district_Canoas_Corredores
 neighborhood_Kilómetro_25_Laurel_Corredores_P,15,Kilómetro 25,district_Laurel_Corredores_P
 neighborhood_Playa_Azul_Tárcoles_Garabito_P,15,Playa Azul,district_Tárcoles_Garabito_P
 neighborhood_Hospital_Limón_Limón_L,15,Hospital,district_Limón_Limón_L
-neighborhood_Brisas_Valle_La_Estrella_Limón_L,15,Brisas,district_Valle_La_Estrella_Limón_L
+neighborhood_Brisas_Valle_La_Estrella_Limón_L_15,15,Brisas,district_Valle_La_Estrella_Limón_L
 neighborhood_Polonia_Matama_Limón_L,15,Polonia,district_Matama_Limón_L
 neighborhood_Toro_Amarillo._Guápiles_Pococí_L,15,Toro Amarillo.,district_Guápiles_Pococí_L
 neighborhood_San_Valentín_Jiménez_Pococí_L,15,San Valentín,district_Jiménez_Pococí_L
@@ -1979,7 +1979,7 @@ neighborhood_Mastatal_Chires_Puriscal_SJ,18,Mastatal,district_Chires_Puriscal_SJ
 neighborhood_Nápoles_San_Lorenzo_Tarrazú_SJ,18,Nápoles,district_San_Lorenzo_Tarrazú_SJ
 neighborhood_Santo_Cristo_Guadalupe_Goicoechea_SJ,18,Santo Cristo,district_Guadalupe_Goicoechea_SJ
 neighborhood_Tablazo._San_Ignacio_Acosta_SJ,18,Tablazo.,district_San_Ignacio_Acosta_SJ
-neighborhood_San_Pablo_Palmichal_Acosta_SJ,18,San Pablo,district_Palmichal_Acosta_SJ
+neighborhood_San_Pablo_Palmichal_Acosta_SJ_18,18,San Pablo,district_Palmichal_Acosta_SJ
 neighborhood_Zoncuano._Sabanillas_Acosta_SJ,18,Zoncuano.,district_Sabanillas_Acosta_SJ
 neighborhood_Jardines_de_Moravia_San_Vicente_Moravia_SJ,18,Jardines de Moravia,district_San_Vicente_Moravia_SJ
 neighborhood_Santa_Marta_San_Pedro_Montes_de_Oca_SJ,18,Santa Marta,district_San_Pedro_Montes_de_Oca_SJ
@@ -2499,7 +2499,7 @@ neighborhood_Joaquineños_San_Joaquín_Flores_H,02,Joaquineños,district_San_Joa
 neighborhood_Ugalde._Barrantes_Flores_H,02,Ugalde.,district_Barrantes_Flores_H
 neighborhood_Año_2000_Llorente_Flores_H,02,Año 2000,district_Llorente_Flores_H
 neighborhood_Amada_San_Pablo_San_Pablo_H,02,Amada,district_San_Pablo_San_Pablo_H
-neighborhood_Esperanza_Puerto_Viejo_Sarapiquí_H,02,Esperanza,district_Puerto_Viejo_Sarapiquí_H
+neighborhood_Esperanza_Puerto_Viejo_Sarapiquí_H_02,02,Esperanza,district_Puerto_Viejo_Sarapiquí_H
 neighborhood_Arbolitos_(parte)_La_Virgen_Sarapiquí_H,02,Arbolitos (parte),district_La_Virgen_Sarapiquí_H
 neighborhood_Cerro_Negro_(parte)_Las_Horquetas_Sarapiquí_H,02,Cerro Negro (parte),district_Las_Horquetas_Sarapiquí_H
 neighborhood_Chimurria_Llanuras_Del_Gaspar_Sarapiquí_H,02,Chimurria,district_Llanuras_Del_Gaspar_Sarapiquí_H
@@ -2867,7 +2867,7 @@ neighborhood_Bajo_Barrientos_Turrialba_Turrialba_C,22,Bajo Barrientos,district_T
 neighborhood_Selva_(parte)_La_Suiza_Turrialba_C,22,Selva (parte),district_La_Suiza_Turrialba_C
 neighborhood_Estrella_San_Isidro_El_Guarco_C,22,Estrella,district_San_Isidro_El_Guarco_C
 neighborhood_Rincón_de_Ricardo_San_Pablo_San_Pablo_H,22,Rincón de Ricardo,district_San_Pablo_San_Pablo_H
-neighborhood_Esperanza_Puerto_Viejo_Sarapiquí_H,22,Esperanza,district_Puerto_Viejo_Sarapiquí_H
+neighborhood_Esperanza_Puerto_Viejo_Sarapiquí_H_22,22,Esperanza,district_Puerto_Viejo_Sarapiquí_H
 neighborhood_San_Gerardo_(parte)_La_Virgen_Sarapiquí_H,22,San Gerardo (parte),district_La_Virgen_Sarapiquí_H
 neighborhood_Finca_Zona_Once_Las_Horquetas_Sarapiquí_H,22,Finca Zona Once,district_Las_Horquetas_Sarapiquí_H
 neighborhood_San_Roque_Liberia_Liberia_G,22,San Roque,district_Liberia_Liberia_G
@@ -3092,7 +3092,7 @@ neighborhood_Unión_San_José_O_Pizote_Upala_A,25,Unión,district_San_José_O_Pi
 neighborhood_Medio_Queso_Los_Chiles_Los_Chiles_A,25,Medio Queso,district_Los_Chiles_Los_Chiles_A
 neighborhood_Chiz_Turrialba_Turrialba_C,25,Chiz,district_Turrialba_Turrialba_C
 neighborhood_La_Paz_San_Isidro_El_Guarco_C,25,La Paz,district_San_Isidro_El_Guarco_C
-neighborhood_Jardín_Puerto_Viejo_Sarapiquí_H,25,Jardín,district_Puerto_Viejo_Sarapiquí_H
+neighborhood_Jardín_Puerto_Viejo_Sarapiquí_H_25,25,Jardín,district_Puerto_Viejo_Sarapiquí_H
 neighborhood_San_Ramón_La_Virgen_Sarapiquí_H,25,San Ramón,district_La_Virgen_Sarapiquí_H
 neighborhood_Victoria_Liberia_Liberia_G,25,Victoria,district_Liberia_Liberia_G
 neighborhood_Gamalotal_Nicoya_Nicoya_G,25,Gamalotal,district_Nicoya_Nicoya_G
@@ -3345,7 +3345,7 @@ neighborhood_Sándalo_Puerto_Jiménez_Golfito_P,29,Sándalo,district_Puerto_Jim�
 neighborhood_Unión_del_Sur_Pavón_Golfito_P,29,Unión del Sur,district_Pavón_Golfito_P
 neighborhood_Santa_Teresa_Sabalito_Coto_Brus_P,29,Santa Teresa,district_Sabalito_Coto_Brus_P
 neighborhood_Coto_52-53_Corredor_Corredores_P,29,Coto 52-53,district_Corredor_Corredores_P
-neighborhood_Buenos_Aires_Limón_Limón_L,29,Buenos Aires,district_Limón_Limón_L
+neighborhood_Buenos_Aires_Limón_Limón_L_29,29,Buenos Aires,district_Limón_Limón_L
 neighborhood_Gavilán_Valle_La_Estrella_Limón_L,29,Gavilán,district_Valle_La_Estrella_Limón_L
 neighborhood_Suerte_Rita_Pococí_L,29,Suerte,district_Rita_Pococí_L
 neighborhood_San_Miguel_Cariari_Pococí_L,29,San Miguel,district_Cariari_Pococí_L
@@ -3643,7 +3643,7 @@ neighborhood_Bosques_de_Doña_Rosa_La_Asunción_Belén_H,03,Bosques de Doña Ros
 neighborhood_Luisiana_San_Joaquín_Flores_H,03,Luisiana,district_San_Joaquín_Flores_H
 neighborhood_Cristo_Rey_(parte)_Llorente_Flores_H,03,Cristo Rey (parte),district_Llorente_Flores_H
 neighborhood_Asovigui_San_Pablo_San_Pablo_H,03,Asovigui,district_San_Pablo_San_Pablo_H
-neighborhood_Jardín_Puerto_Viejo_Sarapiquí_H,03,Jardín,district_Puerto_Viejo_Sarapiquí_H
+neighborhood_Jardín_Puerto_Viejo_Sarapiquí_H_03,03,Jardín,district_Puerto_Viejo_Sarapiquí_H
 neighborhood_Bajos_de_Chilamate_La_Virgen_Sarapiquí_H,03,Bajos de Chilamate,district_La_Virgen_Sarapiquí_H
 neighborhood_Colonia_Bambú_Las_Horquetas_Sarapiquí_H,03,Colonia Bambú,district_Las_Horquetas_Sarapiquí_H
 neighborhood_Chirriposito_Llanuras_Del_Gaspar_Sarapiquí_H,03,Chirriposito,district_Llanuras_Del_Gaspar_Sarapiquí_H
@@ -4503,7 +4503,7 @@ neighborhood_Bajo_Canoas_Corredores_P,04,Bajo,district_Canoas_Corredores_P
 neighborhood_Bijagual_Laurel_Corredores_P,04,Bijagual,district_Laurel_Corredores_P
 neighborhood_Cerro_Fresco_Jacó_Garabito_P,04,Cerro Fresco,district_Jacó_Garabito_P
 neighborhood_Caletas_Tárcoles_Garabito_P,04,Caletas,district_Tárcoles_Garabito_P
-neighborhood_Buenos_Aires_Limón_Limón_L,04,Buenos Aires,district_Limón_Limón_L
+neighborhood_Buenos_Aires_Limón_Limón_L_04,04,Buenos Aires,district_Limón_Limón_L
 neighborhood_Loras_Valle_La_Estrella_Limón_L,04,Loras,district_Valle_La_Estrella_Limón_L
 neighborhood_Bearesem_Matama_Limón_L,04,Bearesem,district_Matama_Limón_L
 neighborhood_Cecilia_Guápiles_Pococí_L,04,Cecilia,district_Guápiles_Pococí_L
@@ -5102,7 +5102,7 @@ neighborhood_San_Juan_(Quebrada_Palo)_Quesada_San_Carlos_A,55,San Juan (Quebrada
 neighborhood_Zompopa._Nicoya_Nicoya_G,55,Zompopa.,district_Nicoya_Nicoya_G
 neighborhood_Trenzas_Golfito_Golfito_P,55,Trenzas,district_Golfito_Golfito_P
 neighborhood_Valle_Vasconia_Parrita_Parrita_P,55,Valle Vasconia,district_Parrita_Parrita_P
-neighborhood_Brisas_Valle_La_Estrella_Limón_L,55,Brisas,district_Valle_La_Estrella_Limón_L
+neighborhood_Brisas_Valle_La_Estrella_Limón_L_55,55,Brisas,district_Valle_La_Estrella_Limón_L
 neighborhood_Higuerones_San_Isidro_De_El_General_Pérez_Zeledón_SJ,56,Higuerones,district_San_Isidro_De_El_General_Pérez_Zeledón_SJ
 neighborhood_Ronrón_Abajo_Quesada_San_Carlos_A,56,Ronrón Abajo,district_Quesada_San_Carlos_A
 neighborhood_Unión_de_Coto_Golfito_Golfito_P,56,Unión de Coto,district_Golfito_Golfito_P


### PR DESCRIPTION
## Summary
Three unrelated small fixes found during the 16.0->19.0 migration, uncommitted until now:

- **`account_tax_data.xml`**: added `country_id=base.cr` to every CR tax record - Odoo 19 core scopes taxes by country for the tax-country filtering system; without it these taxes don't show up correctly for a CR company.
- **`res_config_settings.py`**: removed `company_dependent=True` from `load_lines`. Its only consumers (`account_move.py`, `api_facturae.py`) read it as a global `ir.config_parameter`, not a per-company field - confirmed via production DB history this was a declaration/consumption mismatch, not intentional. Also fixes a hard crash: Postgres can't auto-cast the existing boolean column to the jsonb type `company_dependent=True` requires in 19.0.
- **`account_portal_templates.xml`**: added an empty anchor div so `sale_timesheet.portal_invoice_page_inherit`'s xpath has something to match - this module fully replaces (not xpath-inherits) `account.portal_invoice_page` with a different DOM structure than core's, so that xpath could never match it as-is.
- **`res.country.neighborhood.csv`**: disambiguated 2 duplicate neighborhood xmlids that collided under 19.0's stricter xmlid uniqueness handling.

Related to #128/#129 (same migration effort, different bugs).

## Test plan
- [ ] CR taxes show up correctly on a company with `country_id = Costa Rica`
- [ ] Settings > Invoicing "load lines" toggle saves/loads correctly, no jsonb cast error on module update
- [ ] Portal invoice page + Sales Timesheet's "View Timesheets" button both render without a registry-load xpath error
- [ ] Full `res.country.neighborhood` data load has no duplicate-xmlid error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfT1zpND4fMTGCkg2GttGp